### PR TITLE
Link to assets and file references

### DIFF
--- a/src/manifest/fileReferences.ts
+++ b/src/manifest/fileReferences.ts
@@ -1,0 +1,39 @@
+import { Node } from 'jsonc-parser';
+import { Range, TextDocument } from 'vscode';
+
+import { getPluginsArrayNode, rangeForOffset } from './utils/iteratePlugins';
+
+function rangeForMatch(document: TextDocument, match: { index: number; length: number }) {
+  return new Range(
+    document.positionAt(match.index),
+    document.positionAt(match.index + match.length)
+  );
+}
+
+export function iterateFileReferences(
+  document: TextDocument,
+  node: Node | undefined,
+  callback: (props: { fileReference: string; range: Range; match: RegExpMatchArray }) => void
+) {
+  const pluginsNode = getPluginsArrayNode(node);
+  const pluginsRange = pluginsNode ? rangeForOffset(document, pluginsNode) : null;
+
+  const matches = document.getText().matchAll(/"(\.\/.*)"/g);
+  for (const match of matches) {
+    if (match.index == null) {
+      continue;
+    }
+    const [, fileReference] = match;
+    const range = rangeForMatch(document, {
+      // index includes the quotes, so move it by 1 to exclude the first quote
+      index: match.index + 1,
+      length: fileReference.length,
+    });
+    // Avoid matching against file imports that are inside of the plugins object.
+    // Otherwise a plugin like `./my-plugin` would overwrite the better link we already created.
+    if (pluginsRange && pluginsRange.contains(range)) {
+      continue;
+    }
+    callback({ fileReference, range, match });
+  }
+}

--- a/src/manifest/utils/iteratePlugins.ts
+++ b/src/manifest/utils/iteratePlugins.ts
@@ -1,4 +1,5 @@
 import { Node } from 'jsonc-parser';
+import { Position, Range, TextDocument } from 'vscode';
 
 import { parseExpoJson } from './parseExpoJson';
 
@@ -19,19 +20,23 @@ export interface PluginRange {
   props?: JsonRange;
 }
 
-function iteratePlugins(appJson: Node | undefined, iterator: (node: Node) => void) {
-  let pluginsNode: Node | undefined;
+export function getPluginsArrayNode(appJson: Node | undefined) {
   if (appJson?.children) {
     for (const child of appJson.children) {
       const children = child.children;
       if (children) {
         if (children && children.length === 2 && isPlugins(children[0].value)) {
-          pluginsNode = children[1];
-          break;
+          return children[1];
         }
       }
     }
   }
+
+  return null;
+}
+
+function iteratePlugins(appJson: Node | undefined, iterator: (node: Node) => void) {
+  const pluginsNode = getPluginsArrayNode(appJson);
 
   if (pluginsNode?.children) {
     pluginsNode.children.forEach(iterator);
@@ -80,7 +85,21 @@ function getPluginResolver(child?: Node): PluginRange | null {
   return null;
 }
 
-export function parseSourceRanges(text: string): PluginRange[] {
+export function rangeForOffset(document: TextDocument, source: JsonRange) {
+  return new Range(
+    document.positionAt(source.offset),
+    document.positionAt(source.offset + source.length)
+  );
+}
+export function rangeForQuotedOffset(document: TextDocument, source: JsonRange) {
+  // For nodes that have quotes
+  return new Range(
+    document.positionAt(source.offset + 1),
+    document.positionAt(source.offset + (source.length - 1))
+  );
+}
+
+export function parseSourceRanges(text: string): { appJson?: Node; plugins: PluginRange[] } {
   const definedPlugins: PluginRange[] = [];
   // Ensure we get the expo object if it exists.
   const { node } = parseExpoJson(text);
@@ -89,7 +108,18 @@ export function parseSourceRanges(text: string): PluginRange[] {
     definedPlugins.push(resolver);
   });
 
-  return definedPlugins;
+  return { appJson: node, plugins: definedPlugins };
+}
+
+export function positionIsInPlugins(document: TextDocument, position: Position) {
+  const { node } = parseExpoJson(document.getText());
+  const pluginsNode = getPluginsArrayNode(node);
+  if (pluginsNode) {
+    const range = rangeForOffset(document, pluginsNode);
+    return range.contains(position);
+  }
+
+  return false;
 }
 
 function isPlugins(value: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2017",
+    "target": "es2020",
     "outDir": "out",
-    "lib": ["es2017"],
+    "lib": ["es2020"],
     "sourceMap": true,
     "rootDir": ".",
     "strict": true,


### PR DESCRIPTION
- Support `⌘ click` to visit a file reference matching `"(\./\.*)"` (the reference must be outside of the plugins array).

<img width="283" alt="Screen Shot 2021-05-17 at 1 44 33 PM" src="https://user-images.githubusercontent.com/9664363/118554291-1e460180-b716-11eb-9023-04c506189b1f.png">

- Support showing a diagnostic error when a file reference doesn't exist relative to the project root. Missing files can still be linked to in case the user wants to jump to the location and press `⌘s` to create the file.

<img width="557" alt="Screen Shot 2021-05-17 at 1 44 46 PM" src="https://user-images.githubusercontent.com/9664363/118554304-243be280-b716-11eb-82e6-46c6d8e9c483.png">

- Make all diagnostic errors exclude the quotes around a string.

<img width="120" alt="Screen Shot 2021-05-17 at 1 44 21 PM" src="https://user-images.githubusercontent.com/9664363/118554322-28680000-b716-11eb-8467-c1d76ea04087.png">

