### PR TITLE
fix: disable helpers on preview files

### DIFF
--- a/src/preview/ExpoConfigCodeProvider.ts
+++ b/src/preview/ExpoConfigCodeProvider.ts
@@ -28,7 +28,8 @@ export class ExpoConfigCodeProvider extends CodeProvider {
   getFileName() {
     // TODO: Maybe manifest.json is better?
 
-    const name = this.configType === ExpoConfigType.PUBLIC ? 'exp.json' : 'app.config.json';
+    // Use _app.config.json to disable all features like auto complete and intellisense on the file.
+    const name = this.configType === ExpoConfigType.PUBLIC ? 'exp.json' : '_app.config.json';
     return name;
   }
 


### PR DESCRIPTION
Previews of the config throw errors because assets cannot be resolved relative to `/`, this PR names the template preview filename `_app.config.json` to disable file matching against it. Bit of a hack, but it seems to be the best solution for right now.