### PR TITLE
fix: resolve webpack bundling issues for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,9 +65,8 @@
   },
   "devDependencies": {
     "@expo/config-plugins": "3.0.1",
-    "@expo/prebuild-config": "2.0.1",
     "@expo/json-file": "^8.2.30",
-    "xdl": "^59.0.46",
+    "@expo/prebuild-config": "2.0.1",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
     "@tsconfig/node12": "^1.0.7",
@@ -89,15 +88,17 @@
     "json5": "^2.2.0",
     "jsonc-parser": "^3.0.0",
     "minimatch": "^3.0.4",
+    "parent-module": "^2.0.0",
     "patch-package": "^6.4.7",
     "prettier": "^2.1.1",
-    "parent-module": "^2.0.0",
     "raw-loader": "^4.0.2",
     "semantic-release": "^17.4.3",
     "typescript": "^4.2.4",
     "vsce": "^1.88.0",
     "vscode-test": "^1.5.2",
     "webpack": "^5.36.2",
-    "webpack-cli": "^4.7.0"
+    "webpack-cli": "^4.7.0",
+    "webpack-node-externals": "^3.0.0",
+    "xdl": "^59.0.46"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const { ESBuildMinifyPlugin } = require('esbuild-loader');
 const path = require('path');
+const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
   target: 'node',
@@ -18,9 +19,7 @@ module.exports = {
   externalsPresets: {
     node: true,
   },
-  externals: {
-    vscode: 'commonjs vscode',
-  },
+  externals: [nodeExternals(), { vscode: 'commonjs vscode' }],
   resolve: {
     extensions: ['.ts', '.js', '.json'],
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,6 @@ module.exports = {
       {
         test: /\.(ts|js)$/,
         loader: 'esbuild-loader',
-        include: path.resolve(__dirname, 'src'),
         options: {
           loader: 'ts',
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14358,6 +14358,11 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
+webpack-node-externals@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz#1a3407c158d547a9feb4229a9e3385b7b60c9917"
+  integrity sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==
+
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"


### PR DESCRIPTION
### Linked issue
This should get `yarn build:production` up and running again, and way faster than before 😄 

### Additional context
- To properly resolve `.d.ts` files in `node_modules`, we need to remove the `include: src` scope
- To avoid trying to bundle `fsevents.node`, we need to add the node externals
    The last time I tried this, it resulted in broken builds. But this time it seems to work like a charm!
