### PR TITLE
fix: missing required libraries and make webpack work with xdl

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "vsce": "^1.88.0",
     "webpack": "^5.36.2",
     "webpack-cli": "^4.7.0",
-    "webpack-node-externals": "^3.0.0",
     "xdl": "^59.0.46"
   }
 }

--- a/patches/xdl+59.0.46.patch
+++ b/patches/xdl+59.0.46.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/xdl/build/Webpack.js b/node_modules/xdl/build/Webpack.js
+index 3f9ff8e..9317821 100644
+--- a/node_modules/xdl/build/Webpack.js
++++ b/node_modules/xdl/build/Webpack.js
+@@ -502,7 +502,8 @@ async function getAvailablePortAsync(options) {
+ 
+ function setMode(mode) {
+   process.env.BABEL_ENV = mode;
+-  process.env.NODE_ENV = mode;
++  // Webpack tries to resolve this, resulting in "production" = mode;
++  // process.env.NODE_ENV = mode;
+ }
+ 
+ function validateBoolOption(name, value, defaultValue) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const { ESBuildMinifyPlugin } = require('esbuild-loader');
 const path = require('path');
-const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
   target: 'node',
@@ -19,7 +18,20 @@ module.exports = {
   externalsPresets: {
     node: true,
   },
-  externals: [nodeExternals(), { vscode: 'commonjs vscode' }],
+  externals: [
+    { vscode: 'commonjs vscode' },
+    // Dirty workaround to prevent modules being bundled,
+    // run `yarn webpack --mode development --stats-error-details` to update.
+    '@babel/helper-regex',
+    'emitter',
+    'fsevents',
+    /^webpack-hot-middleware/i,
+    /^webpack-plugin-serve/i,
+    // This library causes invalid JS, caused by https://github.com/jantimon/html-webpack-plugin/blob/8f8f7c53c4e4f822020d6da9de0304f8c23de08f/index.js#L133
+    // Webpack both shortens the `require: require` -> `require` and replaces require with an internal `__webpack_require(xxx)`.
+    // It's kinda stupid, `{ __webpack_require(xxx) }` is invalid, but we don't need this library within the bundle.
+    'html-webpack-plugin',
+  ],
   resolve: {
     extensions: ['.ts', '.js', '.json'],
   },


### PR DESCRIPTION
### Linked issue
With Webpack external, some fundamental libraries are excluded. Let's fix them by using the list of breaking and not-required dependencies.

### Additional context
Also fixed the release tokens.
