### PR TITLE
chore: add package as release assets for open-source usage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Setup repository
         uses: actions/checkout@v2
@@ -27,6 +29,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --check-files
       - name: Publish to marketplace
-        run: yarn deploy
+        run: yarn vsce publish --yarn
         env:
           VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
+      - name: Package extension
+        run: yarn vsce package
+      - name: Add package to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: vscode-expo-*.vsix

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "build:production": "webpack --mode production",
     "clean": "git clean -xdf ./out ./.vscode-test *tsbuildinfo",
     "test": "node ./out/test/jest/cli.js",
-    "lint": "eslint .",
-    "deploy": "vsce publish --yarn"
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@expo/config-plugins": "^4.0.7",


### PR DESCRIPTION
### Linked issue
This allows us to directly reference the package, without using the vscode marketplace. Ideal for [environments like gitpod](https://www.gitpod.io/docs/vscode-extensions).
