### PR TITLE
feature: add EAS metadata store config schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,12 @@
         "command": "expo.config.prebuild.preview.json",
         "title": "Expo: Preview modifier as JSON"
       }
+    ],
+    "jsonValidation": [
+      {
+        "fileMatch": "store.config.json",
+        "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/schema/metadata-0.json"
+      }
     ]
   },
   "scripts": {


### PR DESCRIPTION
### Linked issue
Add IntelliSense for `store.config.json` (EAS Metadata) to the plugin.

### Additional context
This uses the concept of `contributes.jsonValidation` and pulls the schema directly from the repository, without additional modifications or manual download.

This might become problematic if we have multiple versions. But even then, we could [combine them in a single JSON schema and conditionally apply them based on the `configVersion` constant](https://json-schema.org/understanding-json-schema/reference/conditionals.html?highlight=subschema#if-then-else).