### PR TITLE
chore: upgrade vscode/test-electron to auto-retry failed download attempts

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/vscode": "^1.46.0",
     "@typescript-eslint/eslint-plugin": "^5.3.1",
     "@typescript-eslint/parser": "^5.3.1",
-    "@vscode/test-electron": "^2.1.0",
+    "@vscode/test-electron": "^2.1.5",
     "conventional-changelog-conventionalcommits": "^4.6.0",
     "eslint": "^7.26.0",
     "eslint-config-universe": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,10 +1686,10 @@
     "@typescript-eslint/types" "5.3.1"
     eslint-visitor-keys "^3.0.0"
 
-"@vscode/test-electron@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-2.1.0.tgz#3e787e3ffb354051294529f451e6f0f6529ff8eb"
-  integrity sha512-nE5ha/V+l4WnS0QS5wJhb2S75Ceamif30UOcURHYw+8FoJJHg2g1xM8/dSpvX2Xk4+04Rbl76/ui/tgI5qia+Q==
+"@vscode/test-electron@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-2.1.5.tgz#ac98f8f445ea4590753f5fa0c7f6e4298f08c3b7"
+  integrity sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==
   dependencies:
     http-proxy-agent "^4.0.1"
     https-proxy-agent "^5.0.0"


### PR DESCRIPTION
### Linked issue
I noticed both the Windows and MacOS tests are [randomly erroring with `Error: read ECONNRESET`](https://github.com/expo/vscode-expo/runs/7111939734?check_suite_focus=true#step:8:15). I'm not sure why, but it seems like it could be related to failed vscode download attempts.

### Additional context
See https://github.com/microsoft/vscode-test/pull/154/files
