### PR TITLE
chore: upgrade workflows and use default setup action

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -1,0 +1,20 @@
+name: Setup project
+description: Prepare the project for any CI action
+
+inputs:
+  node-version:
+    description: Version of Node to install
+    default: 16.x
+
+runs:
+  using: composite
+  steps:
+    - name: 🏗 Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: yarn
+
+    - name: 📦 Install dependencies
+      run: yarn install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,23 +15,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: [12.x, 14.x]
+        node: [14.x, 16.x, 18.x]
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+      - name: 🏗 Setup project
+        uses: ./.github/actions/setup-project
         with:
           node-version: ${{ matrix.node }}
-          cache: yarn
-
-      - name: 📦 Install dependencies
-        run: yarn install --frozen-lockfile --check-files
 
       - name: 👷 Build project
         run: yarn build:production

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,16 +11,10 @@ jobs:
       contents: write
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          cache: yarn
-
-      - name: 📦 Install dependencies
-        run: yarn install --frozen-lockfile --check-files
+      - name: 🏗 Setup project
+        uses: ./.github/actions/setup-project
 
       - name: 🎁 Package extension
         run: yarn vsce package
@@ -34,16 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          cache: yarn
-
-      - name: 📦 Install dependencies
-        run: yarn install --frozen-lockfile --check-files
+      - name: 🏗 Setup project
+        uses: ./.github/actions/setup-project
 
       - name: 🚀 Publish to marketplace
         run: yarn vsce publish --yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          cache: yarn
-      
-      - name: 📦 Install dependencies
-        run: yarn install --frozen-lockfile --check-files
+      - name: 🏗 Setup project
+        uses: ./.github/actions/setup-project
 
       - name: 📋 Dry-running release
         if: ${{ github.ref != 'refs/heads/main' || github.event.inputs.release != 'release' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,16 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          cache: yarn
-
-      - name: 📦 Install dependencies
-        run: yarn install --frozen-lockfile --check-files
+      - name: 🏗 Setup project
+        uses: ./.github/actions/setup-project
 
       - name: ✅ Lint project
         run: yarn lint --max-warnings 0
@@ -36,22 +30,17 @@ jobs:
         vscode: [oldest, stable]
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          cache: yarn
-
-      - name: 📦 Install dependencies
-        run: yarn install --frozen-lockfile --check-files
+      - name: 🏗 Setup project
+        uses: ./.github/actions/setup-project
 
       - name: 👷 Build project
         run: yarn build
 
+      # This handles the "oldest" vscode version by looking up our "oldest supported version"
       - name: 🕵️ Set vscode version
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const { engines } = require('./package.json')


### PR DESCRIPTION
### Linked issue
This does a couple of things:
- Bumps up Node versions in workflows
- Bumps up action versions
- Adds a default setup action