### PR TITLE
fix: enable expo xdl intellisense on app.config.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "contributes": {
     "jsonValidation": [
       {
-        "fileMatch": "app.json",
+        "fileMatch": ["app.json", "app.config.json"],
         "url": "https://raw.githubusercontent.com/expo/vscode-expo/schemas/schema/expo-xdl.json"
       },
       {


### PR DESCRIPTION
### Linked issue
We also support `app.config.json`