### PR TITLE
feature: add expo-module.config.json intellisense

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
       {
         "fileMatch": "store.config.json",
         "url": "https://raw.githubusercontent.com/expo/vscode-expo/schemas/schema/eas-metadata.json"
+      },
+      {
+        "fileMatch": "expo-module.config.json",
+        "url": "https://raw.githubusercontent.com/expo/vscode-expo/schemas/schema/expo-module.json"
       }
     ],
     "commands": [


### PR DESCRIPTION
### Linked issue
Fixes #113

### Additional context
There is no automated workflow to manage this schema yet. I'll keep the original issue open because of that. We have a few options:

1. Try to infer the json schema through typedoc from https://cdn.jsdelivr.net/npm/expo-modules-autolinking@0.9.0/build/types.d.ts
2. Add a schema to `expo-modules-autolinking` that we update here, just like `eas-metadata.json`

The manual schema lives here: https://github.com/expo/vscode-expo/blob/schemas/schema/expo-module.json