### PR TITLE
chore: only commit schema changes when actually changed

### DIFF
--- a/.github/workflows/schema-metadata.yml
+++ b/.github/workflows/schema-metadata.yml
@@ -62,13 +62,15 @@ jobs:
           name: schema-metadata
           path: ./schema/
 
-      - name: 🕵️ Inspect schema
+      - name: 🕵️ Latest schema
         id: diff
         run: |
           if [ "$(git diff | wc -l)" -gt "0" ]; then
             echo "⚠️ Schema has changed, see changes below"
             git diff
             exit 1
+          else
+            echo "✅ Schema is up-to-date"
           fi
 
       - name: 🗂 Update schema

--- a/.github/workflows/schema-metadata.yml
+++ b/.github/workflows/schema-metadata.yml
@@ -62,7 +62,17 @@ jobs:
           name: schema-metadata
           path: ./schema/
 
-      - name: 🗂 Store schema
+      - name: 🕵️ Inspect schema
+        id: diff
+        run: |
+          if [ "$(git diff | wc -l)" -gt "0" ]; then
+            echo "⚠️ Schema has changed, see changes below"
+            git diff
+            exit 1
+          fi
+
+      - name: 🗂 Update schema
+        if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         run: |
           git config --global user.name 'Bot'
           git config --global user.email 'github+bot@cedric.dev'

--- a/.github/workflows/schema-xdl.yml
+++ b/.github/workflows/schema-xdl.yml
@@ -63,8 +63,18 @@ jobs:
         with:
           name: schema-xdl
           path: ./schema/
+      
+      - name: 🕵️ Inspect schema
+        id: diff
+        run: |
+          if [ "$(git diff | wc -l)" -gt "0" ]; then
+            echo "⚠️ Schema has changed, see changes below"
+            git diff
+            exit 1
+          fi
 
-      - name: 🗂 Store schema
+      - name: 🗂 Update schema
+        if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         run: |
           git config --global user.name 'Bot'
           git config --global user.email 'github+bot@cedric.dev'

--- a/.github/workflows/schema-xdl.yml
+++ b/.github/workflows/schema-xdl.yml
@@ -64,13 +64,15 @@ jobs:
           name: schema-xdl
           path: ./schema/
       
-      - name: 🕵️ Inspect schema
+      - name: 🕵️ Latest schema
         id: diff
         run: |
           if [ "$(git diff | wc -l)" -gt "0" ]; then
             echo "⚠️ Schema has changed, see changes below"
             git diff
             exit 1
+          else
+            echo "✅ Schema is up-to-date"
           fi
 
       - name: 🗂 Update schema


### PR DESCRIPTION
### Linked issue
This should minimize the amount of "failure" in the schema workflows.

### Additional context
Copied from https://github.com/expo/expo-github-action/commit/ee415b027afce4c15cabcc6fa2f8368530a36c08

Tested workflows:
  - schema-eas-metadata - https://github.com/expo/vscode-expo/actions/runs/2796479961
  - schema-expo-xdl - https://github.com/expo/vscode-expo/actions/runs/2796481842