### PR TITLE
chore: add automated eas schema workflow

### DIFF
--- a/.github/workflows/schema-eas.yml
+++ b/.github/workflows/schema-eas.yml
@@ -40,10 +40,12 @@ jobs:
           script: |
             const inputVersion = "${{ github.event.inputs.version || 'latest' }}";
             const { stdout: latestVersion } = await exec.getExecOutput('npm', ['view', 'eas-cli', 'dist-tags.latest']);
+            const resolvedVersion = inputVersion === 'latest'
+              ? latestVersion.trim()
+              : inputVersion.trim();
 
-            inputVersion === 'latest'
-              ? core.setOutput('resolved', latestVersion.trim())
-              : core.setOutput('resolved', inputVersion.trim());
+            core.setOutput('resolved', resolvedVersion);
+            console.log('✅ Resolved versions for eas-cli', { inputVersion, latestVersion, resolvedVersion });
 
       - name: 👷 Download schema
         run: |

--- a/.github/workflows/schema-eas.yml
+++ b/.github/workflows/schema-eas.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           mkdir -p ./schema
           rm -f ./schema/eas.json
-          curl https://raw.githubusercontent.com/expo/eas-cli/v${{ steps.version.outputs.resolved }}/packages/eas-cli/schema/eas.json -o ./schema/eas.json
+          curl https://raw.githubusercontent.com/expo/eas-cli/v${{ steps.version.outputs.resolved }}/packages/eas-json/schema/eas.schema.json -o ./schema/eas.json
 
       - name: 📋 Upload schema
         uses: actions/upload-artifact@v3

--- a/.github/workflows/schema-eas.yml
+++ b/.github/workflows/schema-eas.yml
@@ -1,0 +1,95 @@
+name: schema-eas
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'scripts/**'
+      - package.json
+  workflow_dispatch:
+    inputs:
+      version:
+        description: EAS CLI tag or exact version to use (without `v`)
+        type: string
+        default: latest
+      storage:
+        description: Update the EAS schema in storage?
+        type: choice
+        default: skip
+        options:
+          - skip
+          - update-schema
+  schedule:
+    # daily at 07:00h UTC
+    - cron: 0 7 * * *
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup project
+        uses: ./.github/actions/setup-project
+
+      - name: 🌐 Resolve version
+        id: version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const inputVersion = "${{ github.event.inputs.version || 'latest' }}";
+            const { stdout: latestVersion } = await exec.getExecOutput('npm', ['view', 'eas-cli', 'dist-tags.latest']);
+
+            inputVersion === 'latest'
+              ? core.setOutput('resolved', latestVersion.trim())
+              : core.setOutput('resolved', inputVersion.trim());
+
+      - name: 👷 Download schema
+        run: |
+          mkdir -p ./schema
+          rm -f ./schema/eas.json
+          curl https://raw.githubusercontent.com/expo/eas-cli/v${{ steps.version.resolved }}/packages/eas-cli/schema/eas.json -o ./schema/eas.json
+
+      - name: 📋 Upload schema
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: schema-eas
+          path: ./schema/eas.json
+
+  publish:
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.storage == 'update-schema' }}
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+        with:
+          ref: schemas
+
+      - name: 📋 Download schema
+        uses: actions/download-artifact@v3
+        with:
+          name: schema-eas
+          path: ./schema/
+
+      - name: 🕵️ Latest schema
+        id: diff
+        run: |
+          if [ "$(git diff | wc -l)" -gt "0" ]; then
+            echo "⚠️ Schema has changed, see changes below"
+            git diff
+            exit 1
+          else
+            echo "✅ Schema is up-to-date"
+          fi
+
+      - name: 🗂 Update schema
+        if: ${{ failure() && steps.diff.conclusion == 'failure' }}
+        run: |
+          git config --global user.name 'Bot'
+          git config --global user.email 'github+bot@cedric.dev'
+          git add ./schema
+          git commit -am "chore: generate eas schema for $(date +"%Y-%m-%dT%H-%M-%S%z")"
+          git push

--- a/.github/workflows/schema-eas.yml
+++ b/.github/workflows/schema-eas.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           mkdir -p ./schema
           rm -f ./schema/eas.json
-          curl https://raw.githubusercontent.com/expo/eas-cli/v${{ steps.version.resolved }}/packages/eas-cli/schema/eas.json -o ./schema/eas.json
+          curl https://raw.githubusercontent.com/expo/eas-cli/v${{ steps.version.outputs.resolved }}/packages/eas-cli/schema/eas.json -o ./schema/eas.json
 
       - name: 📋 Upload schema
         uses: actions/upload-artifact@v3

--- a/.github/workflows/schema-metadata.yml
+++ b/.github/workflows/schema-metadata.yml
@@ -40,10 +40,12 @@ jobs:
           script: |
             const inputVersion = "${{ github.event.inputs.version || 'latest' }}";
             const { stdout: latestVersion } = await exec.getExecOutput('npm', ['view', 'eas-cli', 'dist-tags.latest']);
+            const resolvedVersion = inputVersion === 'latest'
+              ? latestVersion.trim()
+              : inputVersion.trim();
 
-            inputVersion === 'latest'
-              ? core.setOutput('resolved', latestVersion.trim())
-              : core.setOutput('resolved', inputVersion.trim());
+            core.setOutput('resolved', resolvedVersion);
+            console.log('✅ Resolved versions for eas-cli', { inputVersion, latestVersion, resolvedVersion });
 
       - name: 👷 Download schema
         run: |

--- a/.github/workflows/schema-metadata.yml
+++ b/.github/workflows/schema-metadata.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: EAS CLI tag or exact version to use
+        description: EAS CLI tag or exact version to use (without `v`)
         type: string
         default: latest
       storage:
@@ -38,6 +38,24 @@ jobs:
           mkdir -p ./schema
           rm -f ./schema/eas-metadata.json
           curl https://cdn.jsdelivr.net/npm/eas-cli@${{ github.event.inputs.version || 'latest' }}/schema/metadata-0.json -o ./schema/eas-metadata.json
+
+      - name: 🌐 Resolve version
+        id: version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const inputVersion = "${{ github.event.inputs.version || 'latest' }}";
+            const { stdout: latestVersion } = await exec.getExecOutput('npm', ['view', 'eas-cli', 'dist-tags.latest']);
+
+            inputVersion === 'latest'
+              ? core.setOutput('resolved', latestVersion.trim())
+              : core.setOutput('resolved', inputVersion.trim());
+
+      - name: 👷 Download schema
+        run: |
+          mkdir -p ./schema
+          rm -f ./schema/eas-metadata.json
+          curl https://raw.githubusercontent.com/expo/eas-cli/v${{ steps.version.resolved }}/packages/eas-cli/schema/metadata-0.json -o ./schema/eas-metadata.json
 
       - name: 📋 Upload schema
         uses: actions/upload-artifact@v3

--- a/.github/workflows/schema-metadata.yml
+++ b/.github/workflows/schema-metadata.yml
@@ -33,12 +33,6 @@ jobs:
       - name: 🏗 Setup project
         uses: ./.github/actions/setup-project
 
-      - name: 👷 Download schema
-        run: |
-          mkdir -p ./schema
-          rm -f ./schema/eas-metadata.json
-          curl https://cdn.jsdelivr.net/npm/eas-cli@${{ github.event.inputs.version || 'latest' }}/schema/metadata-0.json -o ./schema/eas-metadata.json
-
       - name: 🌐 Resolve version
         id: version
         uses: actions/github-script@v6
@@ -55,7 +49,7 @@ jobs:
         run: |
           mkdir -p ./schema
           rm -f ./schema/eas-metadata.json
-          curl https://raw.githubusercontent.com/expo/eas-cli/v${{ steps.version.resolved }}/packages/eas-cli/schema/metadata-0.json -o ./schema/eas-metadata.json
+          curl https://raw.githubusercontent.com/expo/eas-cli/v${{ steps.version.outputs.resolved }}/packages/eas-cli/schema/metadata-0.json -o ./schema/eas-metadata.json
 
       - name: 📋 Upload schema
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Linked issue
This adds an automated workflow to keep `schemas/eas.json` up to date.

### Additional context
The ownership of this schema is now moved to the expo/eas-cli repository. Before merging this PR:
  - [x] EAS schema should be in the [expo/eas-cli](https://github.com/expo/eas-cli) repository → https://github.com/expo/eas-cli/commit/7eea81ef83e6605edf5e92ff0a59c95aea96390e
  - [ ] EAS CLI should be released to create the tag including this schema

Tested workflow:
  - schema-metadata, with `latest`, https://github.com/expo/vscode-expo/actions/runs/2796676695
  - schema-metadata, with `0.56.0`, https://github.com/expo/vscode-expo/actions/runs/2796683490