### PR TITLE
refactor: use node lookup method instead of custom code

### DIFF
--- a/src/manifest/fileReferences.ts
+++ b/src/manifest/fileReferences.ts
@@ -1,7 +1,7 @@
 import { Node } from 'jsonc-parser';
 import { Range, TextDocument } from 'vscode';
 
-import { getPluginsArrayNode, rangeForOffset } from './utils/iteratePlugins';
+import { findPluginsNode, rangeForOffset } from './utils/iteratePlugins';
 
 function rangeForMatch(document: TextDocument, match: { index: number; length: number }) {
   return new Range(
@@ -15,7 +15,7 @@ export function iterateFileReferences(
   node: Node | undefined,
   callback: (props: { fileReference: string; range: Range; match: RegExpMatchArray }) => void
 ) {
-  const pluginsNode = getPluginsArrayNode(node);
+  const pluginsNode = findPluginsNode(node);
   const pluginsRange = pluginsNode ? rangeForOffset(document, pluginsNode) : null;
 
   const matches = document.getText().matchAll(/"(\.\/.*)"/g);

--- a/src/manifest/utils/iteratePlugins.ts
+++ b/src/manifest/utils/iteratePlugins.ts
@@ -1,4 +1,4 @@
-import { Node } from 'jsonc-parser';
+import { findNodeAtLocation, Node } from 'jsonc-parser';
 import { Position, Range, TextDocument } from 'vscode';
 
 import { parseExpoJson } from './parseExpoJson';
@@ -20,23 +20,12 @@ export interface PluginRange {
   props?: JsonRange;
 }
 
-export function getPluginsArrayNode(appJson: Node | undefined) {
-  if (appJson?.children) {
-    for (const child of appJson.children) {
-      const children = child.children;
-      if (children) {
-        if (children && children.length === 2 && isPlugins(children[0].value)) {
-          return children[1];
-        }
-      }
-    }
-  }
-
-  return null;
+export function findPluginsNode(appJson: Node | undefined) {
+  return appJson ? findNodeAtLocation(appJson, ['plugins']) : null;
 }
 
 function iteratePlugins(appJson: Node | undefined, iterator: (node: Node) => void) {
-  const pluginsNode = getPluginsArrayNode(appJson);
+  const pluginsNode = findPluginsNode(appJson);
 
   if (pluginsNode?.children) {
     pluginsNode.children.forEach(iterator);
@@ -113,15 +102,11 @@ export function parseSourceRanges(text: string): { appJson?: Node; plugins: Plug
 
 export function positionIsInPlugins(document: TextDocument, position: Position) {
   const { node } = parseExpoJson(document.getText());
-  const pluginsNode = getPluginsArrayNode(node);
+  const pluginsNode = findPluginsNode(node);
   if (pluginsNode) {
     const range = rangeForOffset(document, pluginsNode);
     return range.contains(position);
   }
 
   return false;
-}
-
-function isPlugins(value: string) {
-  return value === 'plugins';
 }


### PR DESCRIPTION
### Linked issue
We don't need to iterate over every node, we can just ask `jsonc` to find nodes at `expo.plugins` or something like that.
