### PR TITLE
fix: set language for app manifests and eas to jsonc

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,17 @@
           "description": "Exclude file suggestions for file references in app manifest, using glob patterns."
         }
       }
-    }
+    },
+    "languages": [
+      {
+        "id": "jsonc",
+        "filenames": [
+          "app.json",
+          "app.config.json",
+          "eas.json"
+        ]
+      }
+    ]
   },
   "scripts": {
     "postinstall": "patch-package",


### PR DESCRIPTION
### Linked issue
Fixes #66

### Additional context
Note that we support JSON5 instead of the non-spec-conform-thing called "JSON with Comments (JSONC)". Unfortunately, this is what ships with vscode by default. JSON5 isn't available without other extensions that register the grammar.

See: https://github.com/microsoft/vscode/issues/100688
