### PR TITLE
fix: set `null` as default for exclude glob patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
         },
         "expo.appManifest.fileReferences.excludeGlobPatterns": {
           "type": "object",
+          "default": null,
           "patternProperties": {
             ".*": {
               "type": "boolean",


### PR DESCRIPTION
### Linked issue
Fixes #135

### Additional context
This sets the default to `null`, exactly how we use it in the configuration fetching code.
