### PR TITLE
fix: app manifest asset linking

### DIFF
--- a/src/manifest/utils/parseExpoJson.ts
+++ b/src/manifest/utils/parseExpoJson.ts
@@ -8,7 +8,7 @@ export const appJsonPattern = {
   scheme: 'file',
   // Match against app.json and app.config.json
   pattern: '**/*/app{,.config}.json',
-  language: 'json',
+  language: 'jsonc',
 };
 
 export function isAppJson(document: TextDocument) {


### PR DESCRIPTION
### Linked issue
This fixes #139, turns out to be the language filter. That was changed in the fix for #66.
