### PR TITLE
chore: add current file test launch option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -62,6 +62,27 @@
       "preLaunchTask": "launch-test-development"
     },
     {
+      "name": "Test: current file (development)",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "${workspaceFolder}/test/fixture",
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/test/jest/runner",
+        "--disable-extensions"
+      ],
+      "env": {
+        "VSCODE_EXPO_DEBUG": "vscode-expo*",
+        "VSCODE_EXPO_TELEMETRY_KEY": null,
+        "VSCODE_EXPO_TEST_PATTERN": "${fileBasenameNoExtension}"
+      },
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "launch-test-development"
+    },
+    {
       "name": "Test (production)",
       "type": "extensionHost",
       "request": "launch",

--- a/test/jest/runner.ts
+++ b/test/jest/runner.ts
@@ -21,6 +21,10 @@ export async function run() {
       ...(jestConfig.setupFilesAfterEnv ?? []),
     ],
     snapshotResolver: resolve(jestConfig.rootDir, './out/test/jest/snapshots.js'),
+    // Set the test pattern to run, if any
+    testPathPattern: process.env['VSCODE_EXPO_TEST_PATTERN']
+      ? [process.env['VSCODE_EXPO_TEST_PATTERN']]
+      : undefined,
   };
 
   const { results } = await runCLI(config, [config.rootDir]);


### PR DESCRIPTION
### Linked issue
This is great when focusing on a single Jest file. You only have to open that file and run this new `Test: current file (development)` to only run those tests.