### PR TITLE
chore: bump vscode to min 1.67.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "./out/src/extension.js",
   "engines": {
-    "vscode": "^1.65.0"
+    "vscode": "^1.66.0"
   },
   "categories": [
     "Other"
@@ -153,7 +153,7 @@
     "@types/jest": "^26.0.23",
     "@types/minimatch": "^3.0.5",
     "@types/node": "^16.11.56",
-    "@types/vscode": "^1.65.0",
+    "@types/vscode": "^1.66.0",
     "@typescript-eslint/eslint-plugin": "^5.30.3",
     "@typescript-eslint/parser": "^5.30.3",
     "@vscode/extension-telemetry": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "./out/src/extension.js",
   "engines": {
-    "vscode": "^1.62.0"
+    "vscode": "^1.63.0"
   },
   "categories": [
     "Other"
@@ -153,7 +153,7 @@
     "@types/jest": "^26.0.23",
     "@types/minimatch": "^3.0.5",
     "@types/node": "^16.11.56",
-    "@types/vscode": "^1.62.0",
+    "@types/vscode": "^1.63.0",
     "@typescript-eslint/eslint-plugin": "^5.30.3",
     "@typescript-eslint/parser": "^5.30.3",
     "@vscode/extension-telemetry": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "./out/src/extension.js",
   "engines": {
-    "vscode": "^1.64.0"
+    "vscode": "^1.65.0"
   },
   "categories": [
     "Other"
@@ -153,7 +153,7 @@
     "@types/jest": "^26.0.23",
     "@types/minimatch": "^3.0.5",
     "@types/node": "^16.11.56",
-    "@types/vscode": "^1.64.0",
+    "@types/vscode": "^1.65.0",
     "@typescript-eslint/eslint-plugin": "^5.30.3",
     "@typescript-eslint/parser": "^5.30.3",
     "@vscode/extension-telemetry": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "./out/src/extension.js",
   "engines": {
-    "vscode": "^1.61.0"
+    "vscode": "^1.62.0"
   },
   "categories": [
     "Other"
@@ -153,7 +153,7 @@
     "@types/jest": "^26.0.23",
     "@types/minimatch": "^3.0.5",
     "@types/node": "^16.11.56",
-    "@types/vscode": "^1.61.0",
+    "@types/vscode": "^1.62.0",
     "@typescript-eslint/eslint-plugin": "^5.30.3",
     "@typescript-eslint/parser": "^5.30.3",
     "@vscode/extension-telemetry": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "./out/src/extension.js",
   "engines": {
-    "vscode": "^1.66.0"
+    "vscode": "^1.67.0"
   },
   "categories": [
     "Other"
@@ -153,7 +153,7 @@
     "@types/jest": "^26.0.23",
     "@types/minimatch": "^3.0.5",
     "@types/node": "^16.11.56",
-    "@types/vscode": "^1.66.0",
+    "@types/vscode": "^1.67.0",
     "@typescript-eslint/eslint-plugin": "^5.30.3",
     "@typescript-eslint/parser": "^5.30.3",
     "@vscode/extension-telemetry": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "./out/src/extension.js",
   "engines": {
-    "vscode": "^1.59.0"
+    "vscode": "^1.59.1"
   },
   "categories": [
     "Other"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "./out/src/extension.js",
   "engines": {
-    "vscode": "^1.60.0"
+    "vscode": "^1.61.0"
   },
   "categories": [
     "Other"
@@ -153,7 +153,7 @@
     "@types/jest": "^26.0.23",
     "@types/minimatch": "^3.0.5",
     "@types/node": "^16.11.56",
-    "@types/vscode": "^1.60.0",
+    "@types/vscode": "^1.61.0",
     "@typescript-eslint/eslint-plugin": "^5.30.3",
     "@typescript-eslint/parser": "^5.30.3",
     "@vscode/extension-telemetry": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "./out/src/extension.js",
   "engines": {
-    "vscode": "^1.59.1"
+    "vscode": "^1.60.0"
   },
   "categories": [
     "Other"
@@ -153,7 +153,7 @@
     "@types/jest": "^26.0.23",
     "@types/minimatch": "^3.0.5",
     "@types/node": "^16.11.56",
-    "@types/vscode": "^1.59.0",
+    "@types/vscode": "^1.60.0",
     "@typescript-eslint/eslint-plugin": "^5.30.3",
     "@typescript-eslint/parser": "^5.30.3",
     "@vscode/extension-telemetry": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "./out/src/extension.js",
   "engines": {
-    "vscode": "^1.63.0"
+    "vscode": "^1.64.0"
   },
   "categories": [
     "Other"
@@ -153,7 +153,7 @@
     "@types/jest": "^26.0.23",
     "@types/minimatch": "^3.0.5",
     "@types/node": "^16.11.56",
-    "@types/vscode": "^1.63.0",
+    "@types/vscode": "^1.64.0",
     "@typescript-eslint/eslint-plugin": "^5.30.3",
     "@typescript-eslint/parser": "^5.30.3",
     "@vscode/extension-telemetry": "^0.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,7 +1328,7 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/vscode@^1.66.0":
+"@types/vscode@^1.67.0":
   version "1.72.0"
   resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz#56447ca2eaca34f0d0797c8bb9e51de132f6bb0a"
   integrity sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,7 +1328,7 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/vscode@^1.64.0":
+"@types/vscode@^1.65.0":
   version "1.72.0"
   resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz#56447ca2eaca34f0d0797c8bb9e51de132f6bb0a"
   integrity sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,7 +1328,7 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/vscode@^1.62.0":
+"@types/vscode@^1.63.0":
   version "1.72.0"
   resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz#56447ca2eaca34f0d0797c8bb9e51de132f6bb0a"
   integrity sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,7 +1328,7 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/vscode@^1.63.0":
+"@types/vscode@^1.64.0":
   version "1.72.0"
   resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz#56447ca2eaca34f0d0797c8bb9e51de132f6bb0a"
   integrity sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,7 +1328,7 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/vscode@^1.65.0":
+"@types/vscode@^1.66.0":
   version "1.72.0"
   resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz#56447ca2eaca34f0d0797c8bb9e51de132f6bb0a"
   integrity sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,10 +1328,10 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/vscode@^1.59.0":
-  version "1.70.0"
-  resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.70.0.tgz#9cb14cdaac9f450a7005ae2db49ecee4a084c983"
-  integrity sha512-3/9Fz0F2eBgwciazc94Ien+9u1elnjFg9YAhvAb3qDy/WeFWD9VrOPU7CIytryOVUdbxus8uzL4VZYONA0gDtA==
+"@types/vscode@^1.60.0":
+  version "1.72.0"
+  resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz#56447ca2eaca34f0d0797c8bb9e51de132f6bb0a"
+  integrity sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==
 
 "@types/yargs-parser@*":
   version "21.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,7 +1328,7 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/vscode@^1.60.0":
+"@types/vscode@^1.61.0":
   version "1.72.0"
   resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz#56447ca2eaca34f0d0797c8bb9e51de132f6bb0a"
   integrity sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,7 +1328,7 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/vscode@^1.61.0":
+"@types/vscode@^1.62.0":
   version "1.72.0"
   resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz#56447ca2eaca34f0d0797c8bb9e51de132f6bb0a"
   integrity sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==


### PR DESCRIPTION
### Linked issue
Turns out to be the Tabs API we use in testing. But even with this version, we still have ±6 months of versions backward compatible. I think that's more than enough.