### PR TITLE
feature: add manifest plugin completion provider

### DIFF
--- a/src/__tests__/manifestDiagnostics.e2e.ts
+++ b/src/__tests__/manifestDiagnostics.e2e.ts
@@ -77,7 +77,7 @@ describe(ManifestDiagnosticsProvider, () => {
 
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]).toMatchObject({
-      code: `PLUGIN_INVALID`,
+      code: `PLUGIN_DEFINITION_INVALID`,
       message: 'Plugin definition is empty, expected a file or dependency name',
       severity: DiagnosticSeverity.Warning,
     });
@@ -93,7 +93,7 @@ describe(ManifestDiagnosticsProvider, () => {
 
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]).toMatchObject({
-      code: `PLUGIN_INVALID`,
+      code: `PLUGIN_DEFINITION_INVALID`,
       message: 'Plugin definition is empty, expected a file or dependency name',
       severity: DiagnosticSeverity.Warning,
     });

--- a/src/__tests__/manifestPluginCompletions.e2e.ts
+++ b/src/__tests__/manifestPluginCompletions.e2e.ts
@@ -57,8 +57,8 @@ describe(ManifestPluginCompletionsProvider, () => {
 
     expect(suggestions.items).toEqual(
       expect.arrayContaining([
+        // `node_modules` are disabled by default in `src/settings.ts`
         expect.objectContaining({ label: 'assets' }),
-        expect.objectContaining({ label: 'node_modules' }),
         expect.objectContaining({ label: 'plugins' }),
       ])
     );

--- a/src/__tests__/manifestPluginCompletions.e2e.ts
+++ b/src/__tests__/manifestPluginCompletions.e2e.ts
@@ -1,0 +1,82 @@
+import { commands, CompletionList, TextEditor, window } from 'vscode';
+
+import { ManifestPluginCompletionsProvider } from '../manifestPluginCompletions';
+import {
+  closeAllEditors,
+  findContentRange,
+  getWorkspaceUri,
+  storeOriginalContent,
+} from './utils/vscode';
+
+describe(ManifestPluginCompletionsProvider, () => {
+  let app: TextEditor;
+  let restoreContent: ReturnType<typeof storeOriginalContent>;
+
+  beforeAll(async () => {
+    app = await window.showTextDocument(getWorkspaceUri('manifest-links/app.json'));
+    restoreContent = storeOriginalContent(app);
+  });
+
+  afterEach(async () => {
+    await restoreContent();
+  });
+
+  afterAll(async () => {
+    await closeAllEditors();
+  });
+
+  it('suggests plugins from installed packages', async () => {
+    const range = findContentRange(app, 'expo-system-ui');
+    await app.edit((builder) => builder.replace(range, ''));
+    await app.document.save();
+
+    const suggestions = await commands.executeCommand<CompletionList>(
+      'vscode.executeCompletionItemProvider',
+      app.document.uri,
+      range.start
+    );
+
+    expect(suggestions.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'expo-camera' }),
+        expect.objectContaining({ label: 'expo-system-ui' }),
+      ])
+    );
+  });
+
+  it('suggests folders from local project', async () => {
+    const range = findContentRange(app, './plugins/valid');
+    await app.edit((builder) => builder.replace(range, './'));
+    await app.document.save();
+
+    const suggestions = await commands.executeCommand<CompletionList>(
+      'vscode.executeCompletionItemProvider',
+      app.document.uri,
+      range.start
+    );
+
+    expect(suggestions.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'assets' }),
+        expect.objectContaining({ label: 'node_modules' }),
+        expect.objectContaining({ label: 'plugins' }),
+      ])
+    );
+  });
+
+  it('suggests plugins from local project', async () => {
+    const range = findContentRange(app, './plugins/valid');
+    await app.edit((builder) => builder.replace(range, './plugins/'));
+    await app.document.save();
+
+    const suggestions = await commands.executeCommand<CompletionList>(
+      'vscode.executeCompletionItemProvider',
+      app.document.uri,
+      range.start
+    );
+
+    expect(suggestions.items).toEqual(
+      expect.arrayContaining([expect.objectContaining({ label: 'valid.js' })])
+    );
+  });
+});

--- a/src/__tests__/manifestPluginCompletions.e2e.ts
+++ b/src/__tests__/manifestPluginCompletions.e2e.ts
@@ -58,8 +58,14 @@ describe(ManifestPluginCompletionsProvider, () => {
     expect(suggestions.items).toEqual(
       expect.arrayContaining([
         // `node_modules` are disabled by default in `src/settings.ts`
-        expect.objectContaining({ label: 'assets' }),
-        expect.objectContaining({ label: 'plugins' }),
+        expect.objectContaining({
+          label: 'assets/',
+          command: expect.objectContaining({ command: 'editor.action.triggerSuggest' }),
+        }),
+        expect.objectContaining({
+          label: 'plugins/',
+          command: expect.objectContaining({ command: 'editor.action.triggerSuggest' }),
+        }),
       ])
     );
   });

--- a/src/completion/provider/createCompletionItem.ts
+++ b/src/completion/provider/createCompletionItem.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { Config } from './configuration/getConfiguration';
@@ -22,30 +21,6 @@ export function createPathCompletionItem(
       );
 }
 
-export function createNodeModuleItem(
-  pluginInfo: {
-    plugin: Function;
-    pluginFile: string;
-    pluginReference: string;
-    isPluginFile: boolean;
-  },
-  importRange: vscode.Range
-): vscode.CompletionItem {
-  const moduleName = pluginInfo.pluginReference;
-  //   const hasProps = pluginInfo.plugin.length > 1
-  return {
-    label: moduleName,
-    kind: vscode.CompletionItemKind.Module,
-    range: importRange,
-    insertText: new vscode.SnippetString(moduleName),
-    // Add a detail text on the right of the suggestion that shows the filename.
-    // This can be useful for packages like lodash which don't use `app.plugin.js`.
-    detail: path.basename(pluginInfo.pluginFile),
-    // Sort app.plugin.js plugins higher since we can be sure that they have a valid plugin.
-    sortText: `a_${pluginInfo.isPluginFile ? 'a' : 'b'}_${moduleName}`,
-  };
-}
-
 function createFolderItem(
   fileInfo: FileInfo,
   autoSlash: boolean,
@@ -56,7 +31,7 @@ function createFolderItem(
   return {
     label: fileInfo.file,
     kind: vscode.CompletionItemKind.Folder,
-    range: importRange,
+    // range: importRange,
     insertText: new vscode.SnippetString(newText),
     sortText: `d_${fileInfo.file}`,
     // If we auto slash, then trigger the next suggestion automatically.
@@ -79,7 +54,7 @@ function createFileItem(
   return {
     label: fileInfo.file,
     kind: vscode.CompletionItemKind.File,
-    range: context.importRange,
+    // range: context.importRange,
     insertText,
     sortText: `c_${fileInfo.file}`,
   };

--- a/src/expo/manifest.ts
+++ b/src/expo/manifest.ts
@@ -1,20 +1,9 @@
-import {
-  resolveConfigPluginFunction,
-  resolveConfigPluginFunctionWithInfo,
-} from '@expo/config-plugins/build/utils/plugin-resolver';
-import { Node, Range } from 'jsonc-parser';
+import { Range } from 'jsonc-parser';
 import { DocumentFilter } from 'vscode';
-
-import { resetModuleFrom } from '../utils/module';
 
 export type FileReference = {
   filePath: string;
   fileRange: Range;
-};
-
-type PluginDefiniton = {
-  nameValue: string;
-  nameRange: Range;
 };
 
 /**
@@ -50,48 +39,4 @@ export function getFileReferences(manifest: string): FileReference[] {
   }
 
   return references;
-}
-
-/**
- * Get the plugin definition from manifest node.
- * Both the `name` and it's `range` include the quotes.
- * This supports different plugin definitions:
- *   - `"plugins": ["./my-plguin.js"]`
- *   - `"plugins": ["expo-camera"]`
- *   - `"plugins": [["expo-camera", [...]]`
- */
-export function getPluginDefinition(plugin: Node): PluginDefiniton {
-  const name = plugin.children?.length ? plugin.children[0] : plugin;
-
-  return {
-    nameValue: name.value,
-    nameRange: {
-      // Exclude the quotes from the range
-      offset: name.offset + 1,
-      length: name.length - 2,
-    },
-  };
-}
-
-/**
- * Try to resolve the config plugin information.
- * This resets previously imported modules to reload this information.
- * When it fails to resolve the config plugin, undefined is returned.
- */
-export function resolvePluginInfo(dir: string, name: string) {
-  resetModuleFrom(dir, name);
-
-  try {
-    return resolveConfigPluginFunctionWithInfo(dir, name);
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Try to resolve the actual config plugin function.
- * When it fails to resolve the config plugin, an error is thrown.
- */
-export function resolvePluginFunctionUnsafe(dir: string, name: string) {
-  return resolveConfigPluginFunction(dir, name);
 }

--- a/src/expo/plugin.ts
+++ b/src/expo/plugin.ts
@@ -63,6 +63,8 @@ export function resolvePluginFunctionUnsafe(dir: string, name: string): PluginFu
 /**
  * Resolve all installed plugin info from the project.
  * This uses the `package.json` to find all installed plugins.
+ *
+ * @todo Investigate potential issues with monorepos
  */
 export function resolveInstalledPluginInfo(
   project: ExpoProject,

--- a/src/expo/plugin.ts
+++ b/src/expo/plugin.ts
@@ -1,0 +1,83 @@
+import {
+  resolveConfigPluginFunction,
+  resolveConfigPluginFunctionWithInfo,
+} from '@expo/config-plugins/build/utils/plugin-resolver';
+import { findNodeAtLocation, getNodeValue, Node, Range } from 'jsonc-parser';
+
+import { truthy } from '../utils/array';
+import { resetModuleFrom } from '../utils/module';
+import { ExpoProject } from './project';
+
+export type PluginDefiniton = {
+  nameValue: string;
+  nameRange: Range;
+};
+
+export type PluginInfo = NonNullable<ReturnType<typeof resolveConfigPluginFunctionWithInfo>>;
+export type PluginFunction = ReturnType<typeof resolveConfigPluginFunction>;
+
+/**
+ * Get the plugin definition from manifest node.
+ * Both the `name` and it's `range` include the quotes.
+ * This supports different plugin definitions:
+ *   - `"plugins": ["./my-plguin.js"]`
+ *   - `"plugins": ["expo-camera"]`
+ *   - `"plugins": [["expo-camera", [...]]`
+ */
+export function getPluginDefinition(plugin: Node): PluginDefiniton {
+  const name = plugin.children?.length ? plugin.children[0] : plugin;
+
+  return {
+    nameValue: name.value,
+    nameRange: {
+      // Exclude the quotes from the range
+      offset: name.offset + 1,
+      length: name.length - 2,
+    },
+  };
+}
+
+/**
+ * Try to resolve the config plugin information.
+ * This resets previously imported modules to reload this information.
+ * When it fails to resolve the config plugin, undefined is returned.
+ */
+export function resolvePluginInfo(dir: string, name: string): PluginInfo | undefined {
+  resetModuleFrom(dir, name);
+
+  try {
+    return resolveConfigPluginFunctionWithInfo(dir, name);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Try to resolve the actual config plugin function.
+ * When it fails to resolve the config plugin, an error is thrown.
+ */
+export function resolvePluginFunctionUnsafe(dir: string, name: string): PluginFunction {
+  return resolveConfigPluginFunction(dir, name);
+}
+
+/**
+ * Resolve all installed plugin info from the project.
+ * This uses the `package.json` to find all installed plugins.
+ */
+export function resolveInstalledPluginInfo(
+  project: ExpoProject,
+  search?: string,
+  maxResults?: number
+): PluginInfo[] {
+  const dependenciesNode = findNodeAtLocation(project.package.tree, ['dependencies']);
+  if (!dependenciesNode) {
+    return [];
+  }
+
+  let dependencies = Object.keys(getNodeValue(dependenciesNode));
+
+  if (search) dependencies = dependencies.filter((name) => name.startsWith(search));
+  if (maxResults !== null) dependencies = dependencies.slice(0, maxResults);
+
+  return dependencies.map((name) => resolvePluginInfo(project.root, name)).filter(truthy);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { setupCompletionItemProvider } from './completion/setupCompletionItemProvider';
 import { ExpoProjectCache } from './expo/project';
 import { ManifestDiagnosticsProvider } from './manifestDiagnostics';
 import { ManifestLinksProvider } from './manifestLinks';
@@ -11,12 +12,13 @@ import { reporter, setupTelemetry, TelemetryEvent } from './utils/telemetry';
 // It helps grouping this code and keeping it maintainable, so disable the eslint rule.
 /* eslint-disable no-new */
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   try {
     const projects = new ExpoProjectCache(context);
 
     setupTelemetry(context);
     setupPreview(context);
+    await setupCompletionItemProvider(context);
 
     new ManifestLinksProvider(context, projects);
     new ManifestDiagnosticsProvider(context, projects);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
 
-import { setupCompletionItemProvider } from './completion/setupCompletionItemProvider';
 import { ExpoProjectCache } from './expo/project';
 import { ManifestDiagnosticsProvider } from './manifestDiagnostics';
 import { ManifestLinksProvider } from './manifestLinks';
+import { ManifestPluginCompletionsProvider } from './manifestPluginCompletions';
 import { setupPreview } from './preview/setupPreview';
 import { reporter, setupTelemetry, TelemetryEvent } from './utils/telemetry';
 
@@ -11,20 +11,18 @@ import { reporter, setupTelemetry, TelemetryEvent } from './utils/telemetry';
 // It helps grouping this code and keeping it maintainable, so disable the eslint rule.
 /* eslint-disable no-new */
 
-export async function activate(context: vscode.ExtensionContext) {
+export function activate(context: vscode.ExtensionContext) {
   try {
-    const start = Date.now();
     const projects = new ExpoProjectCache(context);
 
-    await setupTelemetry(context);
-    await Promise.all([setupCompletionItemProvider(context), setupPreview(context)]);
+    setupTelemetry(context);
+    setupPreview(context);
 
     new ManifestLinksProvider(context, projects);
     new ManifestDiagnosticsProvider(context, projects);
+    new ManifestPluginCompletionsProvider(context, projects);
 
-    reporter?.sendTelemetryEvent(TelemetryEvent.ACTIVATED, undefined, {
-      duration: Date.now() - start,
-    });
+    reporter?.sendTelemetryEvent(TelemetryEvent.ACTIVATED);
   } catch (error) {
     reporter?.sendTelemetryException(error);
     vscode.window.showErrorMessage(

--- a/src/manifestLinks.ts
+++ b/src/manifestLinks.ts
@@ -2,12 +2,8 @@ import { findNodeAtLocation } from 'jsonc-parser';
 import path from 'path';
 import vscode from 'vscode';
 
-import {
-  getFileReferences,
-  getPluginDefinition,
-  manifestPattern,
-  resolvePluginInfo,
-} from './expo/manifest';
+import { getFileReferences, manifestPattern } from './expo/manifest';
+import { getPluginDefinition, resolvePluginInfo } from './expo/plugin';
 import { ExpoProjectCache } from './expo/project';
 import { isManifestFileReferencesEnabled } from './settings';
 import { debug } from './utils/debug';

--- a/src/manifestPluginCompletions.ts
+++ b/src/manifestPluginCompletions.ts
@@ -132,10 +132,19 @@ function createPluginFile(plugin: PluginInfo, pluginFile: string): vscode.Comple
   return item;
 }
 
+/**
+ * Create a new completion item for a folder.
+ * Note, this adds a trailing `/` to the folder and triggers the next suggestion automatically.
+ * While this makes it harder to type `./folder`, `./folder/` is a valid shorthand for `./folder/index.js`.
+ */
 function createFolder(folderPath: string): vscode.CompletionItem {
-  const item = new vscode.CompletionItem(folderPath, vscode.CompletionItemKind.Folder);
+  const item = new vscode.CompletionItem(folderPath + '/', vscode.CompletionItemKind.Folder);
 
   item.sortText = `e_${path.basename(folderPath)}`;
+  item.command = {
+    title: '',
+    command: 'editor.action.triggerSuggest',
+  };
 
   return item;
 }

--- a/src/manifestPluginCompletions.ts
+++ b/src/manifestPluginCompletions.ts
@@ -1,0 +1,141 @@
+import { findNodeAtLocation, findNodeAtOffset, getNodeValue } from 'jsonc-parser';
+import path from 'path';
+import vscode from 'vscode';
+
+import { manifestPattern } from './expo/manifest';
+import { PluginInfo, resolveInstalledPluginInfo, resolvePluginInfo } from './expo/plugin';
+import { ExpoProjectCache } from './expo/project';
+import {
+  getManifestFileReferencesExcludedFiles,
+  isManifestFileReferencesEnabled,
+} from './settings';
+import { truthy } from './utils/array';
+import { debug } from './utils/debug';
+import { fileIsExcluded, fileIsHidden, getDirectoryPath } from './utils/file';
+import { getDocumentRange, isKeyNode } from './utils/json';
+import { ExpoCompletionsProvider } from './utils/vscode';
+
+const log = debug.extend('manifest-plugin-completions');
+
+/** The maximum amount of plugins or files to search for in advance (helps keeping things fast) */
+const MAX_RESULT = 10;
+
+export class ManifestPluginCompletionsProvider extends ExpoCompletionsProvider {
+  private isEnabled = true;
+  private excludedFiles: Record<string, boolean>;
+
+  constructor(extension: vscode.ExtensionContext, projects: ExpoProjectCache) {
+    super(extension, projects, manifestPattern, ['"', '/']);
+
+    this.isEnabled = isManifestFileReferencesEnabled();
+    this.excludedFiles = getManifestFileReferencesExcludedFiles();
+
+    extension.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration((event) => {
+        this.isEnabled = isManifestFileReferencesEnabled();
+        this.excludedFiles = getManifestFileReferencesExcludedFiles();
+      })
+    );
+  }
+
+  public async provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+  ) {
+    if (!this.isEnabled) return null;
+
+    const project = this.projects.fromManifest(document);
+    if (!project?.manifest) {
+      log('Could not resolve project from manifest "%s"', document.fileName);
+      return [];
+    }
+
+    const positionNode = findNodeAtOffset(project.manifest.tree, document.offsetAt(position));
+    if (!positionNode || isKeyNode(positionNode)) return null;
+
+    const plugins = findNodeAtLocation(project.manifest.tree, ['plugins']);
+    const positionInPlugins = plugins && getDocumentRange(document, plugins).contains(position);
+    if (!positionInPlugins) return null;
+
+    const positionValue = getNodeValue(positionNode);
+    const positionIsPath = positionValue && positionValue.startsWith('./');
+
+    if (!positionIsPath && !token.isCancellationRequested) {
+      return createPossibleIncompleteList(
+        resolveInstalledPluginInfo(project, positionValue, MAX_RESULT).map((plugin) =>
+          createPluginModule(plugin)
+        )
+      );
+    }
+
+    if (positionIsPath && !token.isCancellationRequested) {
+      const positionDir = getDirectoryPath(positionValue) ?? '';
+      const entities = await vscode.workspace.fs.readDirectory(
+        vscode.Uri.file(path.join(project.root, positionDir))
+      );
+
+      return entities
+        .map(([entityName, entityType]) => {
+          if (fileIsHidden(entityName) || fileIsExcluded(entityName, this.excludedFiles)) {
+            return null;
+          }
+
+          if (entityType === vscode.FileType.Directory) {
+            return createFolder(entityName);
+          }
+
+          if (path.extname(entityName) === '.js') {
+            const pluginPath = './' + path.join(positionDir, entityName);
+            const plugin = resolvePluginInfo(project.root, pluginPath);
+            if (plugin) {
+              return createPluginFile(plugin, entityName);
+            }
+          }
+        })
+        .filter(truthy);
+    }
+
+    return null;
+  }
+}
+
+function createPossibleIncompleteList(
+  items: vscode.CompletionItem[],
+  isIncomplete?: boolean
+): vscode.CompletionList {
+  return new vscode.CompletionList(
+    items,
+    isIncomplete !== undefined ? isIncomplete : items.length >= MAX_RESULT
+  );
+}
+
+function createPluginModule(plugin: PluginInfo): vscode.CompletionItem {
+  const item = new vscode.CompletionItem(plugin.pluginReference, vscode.CompletionItemKind.Module);
+
+  // Sort app.plugin.js plugins higher since we can be sure that they have a valid plugin.
+  item.sortText = `a_${plugin.isPluginFile ? 'a' : 'b'}_${plugin.pluginReference}`;
+
+  // Add a detail text on the right of the suggestion that shows the filename.
+  // This can be useful for packages which don't use `app.plugin.js`.
+  item.detail = path.basename(plugin.pluginFile);
+
+  return item;
+}
+
+function createPluginFile(plugin: PluginInfo, pluginFile: string): vscode.CompletionItem {
+  const item = new vscode.CompletionItem(pluginFile, vscode.CompletionItemKind.File);
+
+  // Sort app.plugin.js plugins higher since we can be sure that they have a valid plugin.
+  item.sortText = `c_${plugin.isPluginFile ? 'c' : 'd'}_${plugin.pluginReference}`;
+
+  return item;
+}
+
+function createFolder(folderPath: string): vscode.CompletionItem {
+  const item = new vscode.CompletionItem(folderPath, vscode.CompletionItemKind.Folder);
+
+  item.sortText = `e_${path.basename(folderPath)}`;
+
+  return item;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,6 +19,23 @@ export function isManifestFileReferencesEnabled(scope?: ConfigurationScope) {
 }
 
 /**
+ * Get the excluded files configuration, used to filter out path-based suggestions.
+ * This is a combination of multiple glob patterns:
+ *   - `files.exclude` - main vscode file exclusion
+ *   - `expo.appManifest.fileReferences.excludeGlobPatterns` - expo-specific file exclusion
+ */
+export function getManifestFileReferencesExcludedFiles(scope?: ConfigurationScope) {
+  const config = workspace.getConfiguration(undefined, scope);
+
+  return {
+    ...config.get<Record<string, boolean>>('files.exclude', {}),
+    ...config.get<Record<string, boolean>>('expo.appManifest.fileReferences.excludeGlobPatterns', {
+      '**/node_modules': true,
+    }),
+  };
+}
+
+/**
  * Get the manifest file references configuration set.
  * This uses multiple settings from the configuration scope.
  *   - `expo.appManifest.fileReferences.showHiddenFiles`

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,4 @@
+/** A predicate to filter arrays on truthy values, returning a type-safe array. */
+export function truthy<T>(value: T | null | undefined): value is T {
+  return !!value;
+}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,0 +1,39 @@
+import minimatch from 'minimatch';
+import path from 'path';
+
+/**
+ * Get the directory path from a user-provided file path.
+ * This slightly differs from the `path.dirname` function:
+ *   - ./        -> null    (path.dirname: '.')
+ *   - ./abc     -> null    (path.dirname: '.')
+ *   - ./abc/    -> './abc' (path.dirname: '.')
+ *   - ./abc/def -> './abc' (path.dirname: './abc')
+ */
+export function getDirectoryPath(filePath: string) {
+  const dir = path.dirname(filePath);
+  if (dir === '.') {
+    if (filePath.endsWith('/')) {
+      return path.basename(filePath);
+    }
+    return null;
+  }
+  return dir;
+}
+
+export function fileFromSegments(segments: string[]) {
+  return segments[segments.length - 1];
+}
+
+export function fileIsHidden(filePath: string) {
+  return filePath.startsWith('.');
+}
+
+export function fileIsExcluded(filePath: string, filesExcluded?: Record<string, boolean>) {
+  if (!filesExcluded) {
+    return false;
+  }
+
+  return Object.entries(filesExcluded).some(
+    ([pattern, isExcluded]) => isExcluded && minimatch(filePath, pattern)
+  );
+}

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,9 +1,39 @@
-import { Range } from 'jsonc-parser';
+import { Node, Range } from 'jsonc-parser';
 import vscode from 'vscode';
 
 export function getDocumentRange(document: vscode.TextDocument, range: Range): vscode.Range {
   return new vscode.Range(
     document.positionAt(range.offset),
     document.positionAt(range.offset + range.length)
+  );
+}
+
+/**
+ * The range for completion items seems the have a wrong offset and length.
+ * Possibly due to the quotes not being counted in the range, but completion items expect it.
+ * @todo figure out if this is true, and rename the method to reflect this fix.
+ */
+export function rangeForCompletion(range: Range): Range {
+  return {
+    offset: range.offset + 1,
+    length: range.length - 2,
+  };
+}
+
+/**
+ * Determine if the node is a JSON key node.
+ * For that, the node must be either:
+ *   - type of `property`
+ *   - type of `string` and have a parent of type `property`
+ *
+ * @example `{ "some": "value" }` where `some` is a key node
+ */
+export function isKeyNode(node: Node) {
+  if (node.type === 'property') {
+    return true;
+  }
+
+  return (
+    node.type === 'string' && node.parent?.type === 'property' && node.parent.children?.[0] === node
   );
 }

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -1,4 +1,4 @@
-import vscode from 'vscode';
+import vscode, { CompletionItemProvider } from 'vscode';
 
 import { ExpoProjectCache } from '../expo/project';
 
@@ -48,4 +48,24 @@ export abstract class ExpoDiagnosticsProvider {
   public abstract provideDiagnostics(
     document: vscode.TextDocument
   ): vscode.Diagnostic[] | Promise<vscode.Diagnostic[]>;
+}
+
+export abstract class ExpoCompletionsProvider implements CompletionItemProvider {
+  constructor(
+    { subscriptions }: vscode.ExtensionContext,
+    protected projects: ExpoProjectCache,
+    selector: vscode.DocumentSelector,
+    triggerCharacters: string[]
+  ) {
+    subscriptions.push(
+      vscode.languages.registerCompletionItemProvider(selector, this, ...triggerCharacters)
+    );
+  }
+
+  abstract provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken,
+    context: vscode.CompletionContext
+  ): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList<vscode.CompletionItem>>;
 }


### PR DESCRIPTION
### Linked issue
This should replace the `src/completion` functionality, except the asset suggestions.
