### PR TITLE
refactor: drop unused code after dropping most superseded code

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,13 +96,6 @@
           "description": "Enable suggestions for file references in app manifests, like the splash screen. This only applies to \"app.json\" and \"app.config.json\" files.",
           "markdownDescription": "Enable suggestions for file references in app manifests, like the splash screen This only applies to `app.json` and `app.config.json` files."
         },
-        "expo.appManifest.fileReferences.showHiddenFiles": {
-          "type": "boolean",
-          "default": false,
-          "scope": "resource",
-          "description": "Show hidden file suggestions for file references in app manifests, like the icon image.",
-          "markdownDescription": "Show hidden file suggestions for file references in app manifests, like the icon image."
-        },
         "expo.appManifest.fileReferences.excludeGlobPatterns": {
           "type": "object",
           "default": null,

--- a/src/expo/plugin.ts
+++ b/src/expo/plugin.ts
@@ -8,7 +8,7 @@ import { truthy } from '../utils/array';
 import { resetModuleFrom } from '../utils/module';
 import { ExpoProject } from './project';
 
-type PluginDefiniton = {
+export type PluginDefiniton = {
   nameValue: string;
   nameRange: Range;
 };

--- a/src/expo/plugin.ts
+++ b/src/expo/plugin.ts
@@ -8,7 +8,7 @@ import { truthy } from '../utils/array';
 import { resetModuleFrom } from '../utils/module';
 import { ExpoProject } from './project';
 
-export type PluginDefiniton = {
+type PluginDefiniton = {
   nameValue: string;
   nameRange: Range;
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,23 +34,3 @@ export function getManifestFileReferencesExcludedFiles(scope?: ConfigurationScop
     }),
   };
 }
-
-/**
- * Get the manifest file references configuration set.
- * This uses multiple settings from the configuration scope.
- *   - `expo.appManifest.fileReferences.showHiddenFiles`
- *   - `expo.appManifest.fileReferences.excludeGlobPatterns`
- *   - `expo.appManifest.fileReferences.useAbsolutePathsForFileReferences` (hidden)
- *   - `expo.appManifest.fileReferences.mappings` (hidden)
- */
-export function getManifestFileReferencesConfig(scope?: ConfigurationScope) {
-  const config = workspace.getConfiguration('expo.appManifest.fileReferences', scope);
-
-  return {
-    showHiddenFiles: config.get<boolean>('showHiddenFiles', false),
-    filesExclude: config.get<Record<string, string> | null>('excludeGlobPatterns', null),
-    // TODO(cedric): Check if the settings blow this comment are still required
-    absolutePathToWorkspace: config.get<boolean>('useAbsolutePathsForFileReferences', false),
-    mappings: config.get<Record<string, string> | null>('mappings', null),
-  };
-}

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug';
 
 /** The namespace tag used for logging */
-export const TAG = 'vscode-expo';
+const TAG = 'vscode-expo';
 
 /** The root debug logger for the extension, use `debug.extend` to create sub-loggers */
 export const debug = Debug(TAG);

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -20,10 +20,6 @@ export function getDirectoryPath(filePath: string) {
   return dir;
 }
 
-export function fileFromSegments(segments: string[]) {
-  return segments[segments.length - 1];
-}
-
 export function fileIsHidden(filePath: string) {
   return filePath.startsWith('.');
 }

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -9,18 +9,6 @@ export function getDocumentRange(document: vscode.TextDocument, range: Range): v
 }
 
 /**
- * The range for completion items seems the have a wrong offset and length.
- * Possibly due to the quotes not being counted in the range, but completion items expect it.
- * @todo figure out if this is true, and rename the method to reflect this fix.
- */
-export function rangeForCompletion(range: Range): Range {
-  return {
-    offset: range.offset + 1,
-    length: range.length - 2,
-  };
-}
-
-/**
  * Determine if the node is a JSON key node.
  * For that, the node must be either:
  *   - type of `property`


### PR DESCRIPTION
### Linked issue
Cleaning up the codebase, after dropping most except the preview code.