### PR TITLE
chore: upgrade to latest vsce and support prerelease publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,18 @@ on:
       tag:
         description: The tag to publish
         required: true
+      type:
+        description: What type of release is this?
+        required: true
+        type: choice
+        default: release
+        choice:
+          - release
+          - prerelease
 
 jobs:
   github-release:
+    if: ${{ github.event.inputs.type == 'release' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -32,7 +41,34 @@ jobs:
           files: vscode-expo-*.vsix
           tag_name: ${{ github.event.inputs.tag }}
 
-  vscode-marketplace:
+  github-prerelease:
+    if: ${{ github.event.inputs.type == 'prerelease' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: 🏗 Setup project
+        uses: ./.github/actions/setup-project
+
+      - name: 🎁 Package extension
+        run: yarn vsce package --pre-release --yarn
+        env:
+          VSCODE_EXPO_TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}
+
+      - name: 📋 Add package to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: vscode-expo-*.vsix
+          tag_name: ${{ github.event.inputs.tag }}
+          prerelease: true
+
+  vscode-marketplace-release:
+    if: ${{ github.event.inputs.type == 'release' }}
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo from tag
@@ -49,7 +85,26 @@ jobs:
           VSCODE_EXPO_TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}
           VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
 
-  open-vsx:
+  vscode-marketplace-prerelease:
+    if: ${{ github.event.inputs.type == 'prerelease' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo from tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: 🏗 Setup project
+        uses: ./.github/actions/setup-project
+
+      - name: 🚀 Publish to marketplace
+        run: yarn vsce publish --pre-release --yarn
+        env:
+          VSCODE_EXPO_TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}
+          VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
+
+  open-vsx-release:
+    if: ${{ github.event.inputs.type == 'release' }}
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo from tag
@@ -67,5 +122,27 @@ jobs:
 
       - name: 🚀 Publish to open-vsx
         run: npx ovsx publish ./vscode-expo.vsix
+        env:
+          OVSX_PAT: ${{ secrets.OPENVSX_TOKEN }}
+
+  open-vsx-prerelease:
+    if: ${{ github.event.inputs.type == 'prerelease' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo from tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: 🏗 Setup project
+        uses: ./.github/actions/setup-project
+
+      - name: 🎁 Package extension
+        run: yarn vsce package --pre-release --yarn --out ./vscode-expo.vsix
+        env:
+          VSCODE_EXPO_TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}
+
+      - name: 🚀 Publish to open-vsx
+        run: yarn ovsx publish --pre-release ./vscode-expo.vsix
         env:
           OVSX_PAT: ${{ secrets.OPENVSX_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@typescript-eslint/parser": "^5.48.0",
     "@vscode/extension-telemetry": "^0.6.2",
     "@vscode/test-electron": "^2.1.5",
+    "@vscode/vsce": "^2.16.0",
     "arg": "^5.0.2",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "debug": "^4.3.4",
@@ -166,6 +167,7 @@
     "jsonc-parser": "^3.0.0",
     "minimatch": "^3.0.4",
     "node-fetch": "^2.6.7",
+    "ovsx": "^0.8.0",
     "parent-module": "^2.0.0",
     "patch-package": "^6.4.7",
     "prettier": "^2.8.1",
@@ -174,7 +176,6 @@
     "semver": "^7.3.7",
     "sucrase": "^3.20.3",
     "typescript": "^4.9.4",
-    "vsce": "^2.9.2",
     "webpack": "^5.36.2",
     "webpack-cli": "^4.7.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,6 +1527,33 @@
     rimraf "^3.0.2"
     unzipper "^0.10.11"
 
+"@vscode/vsce@^2.15.0", "@vscode/vsce@^2.16.0":
+  version "2.16.0"
+  resolved "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.16.0.tgz#a3ddcf7e84914576f35d891e236bc496c568776f"
+  integrity sha512-BhJ0zO7UxShLFBZM6jwOLt1ZVoqQ4r5Lj/kHNeYp0ICPXhz/erqBSMQnHkRgkjn2L/bh+TYFGkZyguhu/SKsjw==
+  dependencies:
+    azure-devops-node-api "^11.0.1"
+    chalk "^2.4.2"
+    cheerio "^1.0.0-rc.9"
+    commander "^6.1.0"
+    glob "^7.0.6"
+    hosted-git-info "^4.0.2"
+    leven "^3.1.0"
+    markdown-it "^12.3.2"
+    mime "^1.3.4"
+    minimatch "^3.0.3"
+    parse-semver "^1.1.1"
+    read "^1.0.7"
+    semver "^5.1.0"
+    tmp "^0.2.1"
+    typed-rest-client "^1.8.4"
+    url-join "^4.0.1"
+    xml2js "^0.4.23"
+    yauzl "^2.3.1"
+    yazl "^2.2.2"
+  optionalDependencies:
+    keytar "^7.7.0"
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
@@ -3682,6 +3709,11 @@ flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
+follow-redirects@^1.14.6:
+  version "1.15.2"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -6434,6 +6466,18 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
+ovsx@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/ovsx/-/ovsx-0.8.0.tgz#e41dffaa8b6230a684e041c1cfe00d5f5b31344d"
+  integrity sha512-W1U7lgBIbhSB1DcqyGKeenKzmwWYY78SkWd+BUKKyLyqN6w39Uekdr0PKAM7dyBGb0JLtLE7d86A1jJVn8bEng==
+  dependencies:
+    "@vscode/vsce" "^2.15.0"
+    commander "^6.1.0"
+    follow-redirects "^1.14.6"
+    is-ci "^2.0.0"
+    leven "^3.1.0"
+    tmp "^0.2.1"
+
 p-each-series@^2.1.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz#105ab0357ce72b202a8a8b94933672657b5e2a9a"
@@ -8373,32 +8417,6 @@ validate-npm-package-name@^4.0.0:
   integrity sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==
   dependencies:
     builtins "^5.0.0"
-
-vsce@^2.9.2:
-  version "2.11.0"
-  resolved "https://registry.npmjs.org/vsce/-/vsce-2.11.0.tgz#e60aac58ecfc3aec6e40024e13ea8c8d29764aef"
-  integrity sha512-pr9Y0va/HCer0tTifeqaUrK24JJSpRd6oLeF/PY6FtrY41e+lwxiAq6jfMXx4ShAZglYg2rFKoKROwa7E7SEqQ==
-  dependencies:
-    azure-devops-node-api "^11.0.1"
-    chalk "^2.4.2"
-    cheerio "^1.0.0-rc.9"
-    commander "^6.1.0"
-    glob "^7.0.6"
-    hosted-git-info "^4.0.2"
-    keytar "^7.7.0"
-    leven "^3.1.0"
-    markdown-it "^12.3.2"
-    mime "^1.3.4"
-    minimatch "^3.0.3"
-    parse-semver "^1.1.1"
-    read "^1.0.7"
-    semver "^5.1.0"
-    tmp "^0.2.1"
-    typed-rest-client "^1.8.4"
-    url-join "^4.0.1"
-    xml2js "^0.4.23"
-    yauzl "^2.3.1"
-    yazl "^2.2.2"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Linked issue
Unfortunately, semantic release has a sub-optimal way of creating prereleases, so these have to be done by hand. But, when created, we can publish the prerelease as the actual prerelease to marketplace and openvsx.
