### PR TITLE
refactor: change publisher to `expo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
       <img alt="Workflow status" src="https://img.shields.io/github/actions/workflow/status/expo/vscode-expo/test.yml?branch=main&style=flat-square&labelColor=D1D5DA" />
     </picture>
   </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo" title="Install from vscode marketplace">
+  <a href="https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo" title="Install from VS Code Marketplace">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/vscode-marketplace-25292E?style=flat-square&label=%20&logoColor=BCC3CD&labelColor=49505A&logo=Visual%20Studio%20Code">
       <img alt="Install from vscode marketplace" src="https://img.shields.io/badge/vscode-marketplace-6C737C?style=flat-square&label=%20&logoColor=595F68&labelColor=D1D5DA&logo=Visual%20Studio%20Code" />

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@
       <img alt="Workflow status" src="https://img.shields.io/github/actions/workflow/status/expo/vscode-expo/test.yml?branch=main&style=flat-square&labelColor=D1D5DA" />
     </picture>
   </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo" title="Install from vscode marketplace">
+  <a href="https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo" title="Install from vscode marketplace">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/vscode-marketplace-25292E?style=flat-square&label=%20&logoColor=BCC3CD&labelColor=49505A&logo=Visual%20Studio%20Code">
       <img alt="Install from vscode marketplace" src="https://img.shields.io/badge/vscode-marketplace-6C737C?style=flat-square&label=%20&logoColor=595F68&labelColor=D1D5DA&logo=Visual%20Studio%20Code" />
     </picture>
   </a>
-  <a href="https://open-vsx.org/extension/byCedric/vscode-expo" title="Install from open vsx">
+  <a href="https://open-vsx.org/extension/expo/vscode-expo" title="Install from open vsx">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/vscode-open%20vsx-25292E?style=flat-square&label=%20&logoColor=BCC3CD&labelColor=49505A&logo=Eclipse%20IDE" />
       <img alt="Install from open vsx" src="https://img.shields.io/badge/vscode-open%20vsx-6C737C?style=flat-square&label=%20&logoColor=595F68&labelColor=D1D5DA&logo=Eclipse%20IDE" />

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "webpack": "^5.76.0",
     "webpack-cli": "^4.7.0"
   },
-  "publisher": "byCedric",
+  "publisher": "expo",
   "icon": "images/logo-marketplace.png",
   "engines": {
     "vscode": "^1.67.0"


### PR DESCRIPTION
Exciting times ahead for the vscode plugin!

### Todos

- [x] Verify the Expo publisher on vscode marketplace
  → ~~Pending infra deployment~~
  → Done!
- [x] Claim the open-vsx.org `expo` publisher
  → See https://github.com/EclipseFdn/open-vsx.org/issues/1831
  → Thanks to @kineticsquid, this is now done: https://open-vsx.org/extension/expo/vscode-expo
- [x] Contact Microsoft for extension transfer
  → ~~Reached out, awaiting reply~~

    While the [OpenVSX community is awesome in terms of support](https://github.com/EclipseFdn/open-vsx.org/issues/1831#issuecomment-1551490914), and transferability, @microsoft doesn't allow this. I'll deprecate `byCedric.expo-tools`, after we published `expo.expo-tools` on the vscode marketplace.

    It's an absolute bummer, since we lose all reviews and downloads so far, but it is what it is.