### PR TITLE
fix: replace unreliable workflow detection with multiple connection attempts

### DIFF
--- a/src/expo/bundler.ts
+++ b/src/expo/bundler.ts
@@ -14,6 +14,8 @@ export interface InspectableDevice {
   vm: string;
   /** Added in Metro +0.75.x */
   deviceName?: string;
+  /** Only available in this extension */
+  _workflow: 'generic' | 'managed';
 }
 
 /** Get a list of unique device names */
@@ -23,12 +25,28 @@ function getDeviceNames(devices: InspectableDevice[]) {
     .filter((deviceName, index, self) => self.indexOf(deviceName) === index);
 }
 
-export async function fetchDevicesToInspect(metroUrl: string) {
-  return await fetch(metroUrl + '/json/list')
+export async function fetchDevicesToInspect({ host, port }: { host: string; port: string }) {
+  return await fetch(`http://${host}:${port}/json/list`)
     .then((response) => (response.ok ? response.json() : Promise.reject(response)))
-    .then((devices: InspectableDevice[]) =>
-      devices.filter((device) => device.title === INSPECTABLE_DEVICE_TITLE)
+    .then((devices: InspectableDevice[]): InspectableDevice[] =>
+      devices
+        .filter((device) => device.title === INSPECTABLE_DEVICE_TITLE)
+        .map((device) => ({ ...device, _workflow: port === '19000' ? 'managed' : 'generic' }))
     );
+}
+
+/** Attempt to fetch from both `19000` and `8081`, return the data when one of these works */
+export async function fetchDevicesToInspectFromUnknownWorkflow({ host }: { host: string }) {
+  const [classic, modern] = await Promise.allSettled([
+    fetchDevicesToInspect({ host, port: '19000' }),
+    fetchDevicesToInspect({ host, port: '8081' }),
+  ]);
+
+  // Prefer data from modern Expo (dev clients)
+  if (classic.status === 'fulfilled') return classic.value;
+  if (modern.status === 'fulfilled') return modern.value;
+
+  throw new Error(`No bundler found at ${host} on ports 19000 or 8081`);
 }
 
 export function findDeviceByName(devices: InspectableDevice[], deviceName: string) {

--- a/src/expo/project.ts
+++ b/src/expo/project.ts
@@ -119,12 +119,6 @@ export class ExpoProject {
     return this.manifestFile;
   }
 
-  resolveWorkflow() {
-    const hasAndroid = fs.existsSync(path.join(this.root, 'android'));
-    const hasiOS = fs.existsSync(path.join(this.root, 'ios'));
-    return hasAndroid || hasiOS ? 'generic' : 'managed';
-  }
-
   setPackage(content: string) {
     if (content === this.packageFile.content) {
       return this.packageFile;


### PR DESCRIPTION
### Linked issue
We can't infer the project type (and thus "guess" on what port Metro is running) from the folders alone.

You can run a prebuilt project without having `/android` and `/ios` folders, and you can start a classic Expo project in dev client mode with `npx expo start --dev-client`.

Instead, we just try to connect to either `8081` or `19000` and see which one succeeds.
