### PR TITLE
chore: treat all fixtures as non-monorepo projects

### DIFF
--- a/test/fixture/config-js-app/package.json
+++ b/test/fixture/config-js-app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "expo-app",
+  "name": "config-js-app",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {

--- a/test/fixture/config-ts-app/package.json
+++ b/test/fixture/config-ts-app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "expo-app",
+  "name": "config-ts-app",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {

--- a/test/fixture/package.json
+++ b/test/fixture/package.json
@@ -1,11 +1,10 @@
 {
   "private": true,
   "name": "fixture",
-  "workspaces": [
-    "eas-app",
-    "expo-app",
-    "expo-module",
-    "manifest-diagnostics",
-    "manifest-links"
-  ]
+  "workspaces": {
+    "nohoist": ["**"],
+    "packages": [
+      "./*"
+    ]
+  }
 }

--- a/test/jest/environment.ts
+++ b/test/jest/environment.ts
@@ -1,4 +1,5 @@
 import NodeEnvironment from 'jest-environment-node';
+
 class VSCodeEnvironment extends NodeEnvironment {
   public async setup() {
     await super.setup();


### PR DESCRIPTION
### Linked issue
This also automatically adds the fixtures to the workspaces, and solves some conflicting fixture names.