### PR TITLE
fix: mute `react-devtools-core` sourcemap missing error

### DIFF
--- a/src/expoDebuggers.ts
+++ b/src/expoDebuggers.ts
@@ -125,7 +125,11 @@ export class ExpoDebuggersProvider implements vscode.DebugConfigurationProvider 
       // Enable source-loading for `node_modules`, when using `expo/AppEntry.js`
       outFiles: [],
       // But disable certain attempts to resolve non-existing source code
-      resolveSourceMapLocations: ['!**/__prelude__', '!webpack:**'],
+      resolveSourceMapLocations: [
+        '!**/__prelude__/**',
+        '!webpack:**',
+        '!**/node_modules/react-devtools-core/**',
+      ],
       // Disable some internal webpack source-mapping, mostly for React DevTools Backend
       sourceMapPathOverrides: {},
 


### PR DESCRIPTION
### Linked issue
Fixes #186

### Additional context
By adding this to the sourcemaps, the error should not pop up again.
