### PR TITLE
fix: add missing `ms-vscode.js-debug` dependency and activate in expo monorepos

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,9 @@
   "extensionKind": [
     "workspace"
   ],
+  "extensionDependencies": [
+    "ms-vscode.js-debug"
+  ],
   "activationEvents": [
     "workspaceContains:node_modules/expo",
     "workspaceContains:**/node_modules/expo",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
   ],
   "activationEvents": [
     "workspaceContains:node_modules/expo",
+    "workspaceContains:**/node_modules/expo",
     "onDebug",
     "onDebugResolve:expo",
     "onDebugInitialConfigurations",


### PR DESCRIPTION
### Linked issue
Just some missing information for vscode.