### PR TITLE
chore: update debugging snippet using `8081` as default port

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
               "request": "attach",
               "name": "Debug Expo app",
               "projectRoot": "^\"\\${workspaceFolder}\"${1}",
-              "bundlerPort": "${2:19000}",
+              "bundlerPort": "${2:8081}",
               "bundlerHost": "${3:127.0.0.1}"
             }
           }


### PR DESCRIPTION
### Linked issue
Starting from SDK 49, this is now the default port for both `expo-dev-client` _and_ Expo Go projects.