### PR TITLE
fix: send the debugger type to inspector proxy

### DIFF
--- a/src/expoDebuggers.ts
+++ b/src/expoDebuggers.ts
@@ -184,7 +184,7 @@ async function resolveDeviceConfig(config: ExpoDebugConfig, project: ExpoProject
     workflow: device._workflow,
 
     // The address of the device to connect to
-    websocketAddress: device.webSocketDebuggerUrl,
+    websocketAddress: `${device.webSocketDebuggerUrl}&type=vscode`,
 
     // Define the required root paths to resolve source maps
     localRoot: project.root,


### PR DESCRIPTION
### Linked issue
This allows us to selectively patch certain behaviors when debugging from vscode. Like disabling inline source maps, or force `urlRegex` breakpoints to be unbound.

### Additional context
This change anticipates that https://github.com/expo/expo/pull/23258 is going to be merged.
