### PR TITLE
fix: add missing `bundlerPort` for `remoteRoot` when debugging apps

### DIFF
--- a/src/expoDebuggers.ts
+++ b/src/expoDebuggers.ts
@@ -188,7 +188,7 @@ async function resolveDeviceConfig(config: ExpoDebugConfig, project: ExpoProject
 
     // Define the required root paths to resolve source maps
     localRoot: project.root,
-    remoteRoot: `http://${config.bundlerHost}:${config.bundlerPort}`,
+    remoteRoot: `http://${config.bundlerHost}:${config.bundlerPort ?? 8081}`,
   };
 }
 


### PR DESCRIPTION
### Linked issue
Found a small issue in the regex sourcemap lookup. It should not affect anyone but might cause some confusing explanations when debugging unbound breakpoints.