### PR TITLE
chore: add missing `permissions` to github workflow when dry-running release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
   dryrun:
     if: ${{ github.ref != 'refs/heads/main' || github.event.inputs.release != 'release' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v3


### PR DESCRIPTION
### Linked issue
Minor maintenance