### PR TITLE
refactor: bump minimum vscode version to `1.78.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^16.11.56",
         "@types/node-fetch": "^2.6.2",
-        "@types/vscode": "^1.67.0",
+        "@types/vscode": "^1.78.2",
         "@typescript-eslint/eslint-plugin": "^5.48.0",
         "@typescript-eslint/parser": "^5.48.0",
         "@vscode/extension-telemetry": "^0.7.7",
@@ -60,7 +60,7 @@
         "webpack-cli": "^4.7.0"
       },
       "engines": {
-        "vscode": "^1.67.0"
+        "vscode": "^1.78.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^16.11.56",
     "@types/node-fetch": "^2.6.2",
-    "@types/vscode": "^1.67.0",
+    "@types/vscode": "^1.78.2",
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",
     "@vscode/extension-telemetry": "^0.7.7",
@@ -91,7 +91,7 @@
   "publisher": "expo",
   "icon": "images/logo-marketplace.png",
   "engines": {
-    "vscode": "^1.67.0"
+    "vscode": "^1.78.0"
   },
   "categories": [
     "Debuggers",


### PR DESCRIPTION
### Linked issue
This is a realignment of both the CI tests, as well as aligning this version with the current telemetry.

Supersededs #193