### PR TITLE
refactor: use `@expo/*` packages from project when available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@expo/config-plugins": "^4.1.5",
-        "@expo/plist": "0.0.18",
+        "@expo/plist": "^0.0.20",
         "@expo/prebuild-config": "^4.0.3",
         "@vscode/extension-telemetry": "^0.8.4",
         "debug": "^4.3.4",
@@ -1155,6 +1155,16 @@
         "write-file-atomic": "^2.3.0"
       }
     },
+    "node_modules/@expo/config-plugins/node_modules/@expo/plist": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.18.tgz",
+      "integrity": "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==",
+      "dependencies": {
+        "@xmldom/xmldom": "~0.7.0",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^14.0.0"
+      }
+    },
     "node_modules/@expo/config-plugins/node_modules/glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -1293,11 +1303,11 @@
       }
     },
     "node_modules/@expo/plist": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.18.tgz",
-      "integrity": "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.20.tgz",
+      "integrity": "sha512-UXQ4LXCfTZ580LDHGJ5q62jSTwJFFJ1GqBu8duQMThiHKWbMJ+gajJh6rsB6EJ3aLUr9wcauxneL5LVRFxwBEA==",
       "dependencies": {
-        "@xmldom/xmldom": "~0.7.0",
+        "@xmldom/xmldom": "~0.7.7",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^14.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@expo/config-plugins": "^4.1.5",
-    "@expo/plist": "0.0.18",
+    "@expo/plist": "^0.0.20",
     "@expo/prebuild-config": "^4.0.3",
     "@vscode/extension-telemetry": "^0.8.4",
     "debug": "^4.3.4",

--- a/src/expo/plugin.ts
+++ b/src/expo/plugin.ts
@@ -1,10 +1,7 @@
 import { findNodeAtLocation, getNodeValue, Node, Range } from 'jsonc-parser';
 
 import { ExpoProject } from './project';
-import {
-  loadConfigPluginsInfoResolver,
-  loadConfigPluginsResolver,
-} from '../packages/config-plugins';
+import { loadConfigPluginsResolver } from '../packages/config-plugins';
 import { truthy } from '../utils/array';
 import { resetModuleFrom } from '../utils/module';
 
@@ -14,9 +11,7 @@ export type PluginDefiniton = {
 };
 
 export type PluginInfo = NonNullable<
-  ReturnType<
-    ReturnType<typeof loadConfigPluginsInfoResolver>['resolveConfigPluginFunctionWithInfo']
-  >
+  ReturnType<ReturnType<typeof loadConfigPluginsResolver>['resolveConfigPluginFunctionWithInfo']>
 >;
 
 export type PluginFunction = ReturnType<
@@ -53,7 +48,7 @@ export function resolvePluginInfo(projectRoot: string, name: string): PluginInfo
   resetModuleFrom(projectRoot, name);
 
   try {
-    const { resolveConfigPluginFunctionWithInfo } = loadConfigPluginsInfoResolver(projectRoot);
+    const { resolveConfigPluginFunctionWithInfo } = loadConfigPluginsResolver(projectRoot);
     return resolveConfigPluginFunctionWithInfo(projectRoot, name);
   } catch {
     return undefined;

--- a/src/expo/plugin.ts
+++ b/src/expo/plugin.ts
@@ -1,10 +1,10 @@
-import {
-  resolveConfigPluginFunction,
-  resolveConfigPluginFunctionWithInfo,
-} from '@expo/config-plugins/build/utils/plugin-resolver';
 import { findNodeAtLocation, getNodeValue, Node, Range } from 'jsonc-parser';
 
 import { ExpoProject } from './project';
+import {
+  resolveConfigPluginFunction,
+  resolveConfigPluginFunctionWithInfo,
+} from '../packages/config-plugins';
 import { truthy } from '../utils/array';
 import { resetModuleFrom } from '../utils/module';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 
 import { ExpoProjectCache } from './expo/project';
 import { ExpoDebuggersProvider } from './expoDebuggers';
@@ -7,13 +7,19 @@ import { ManifestDiagnosticsProvider } from './manifestDiagnostics';
 import { ManifestLinksProvider } from './manifestLinks';
 import { ManifestPluginCompletionsProvider } from './manifestPluginCompletions';
 import { setupPreview } from './preview/setupPreview';
-import { reporter, setupTelemetry, TelemetryEvent } from './utils/telemetry';
-
-// The contained provider classes are self-registering required subscriptions.
-// It helps grouping this code and keeping it maintainable, so disable the eslint rule.
-/* eslint-disable no-new */
+import {
+  getErrorProperties,
+  reporter,
+  setupTelemetry,
+  TelemetryErrorEvent,
+  TelemetryEvent,
+} from './utils/telemetry';
 
 export async function activate(context: vscode.ExtensionContext) {
+  // The contained provider classes are self-registering required subscriptions.
+  // It helps grouping this code and keeping it maintainable, so disable the eslint rule.
+  /* eslint-disable no-new */
+
   try {
     const projects = new ExpoProjectCache(context);
 
@@ -33,9 +39,6 @@ export async function activate(context: vscode.ExtensionContext) {
       `Oops, looks like we can't fully activate Expo Tools: ${error.message}`
     );
 
-    reporter?.sendTelemetryErrorEvent(TelemetryEvent.ACTIVATED, {
-      message: error.message,
-      stack: error.stack,
-    });
+    reporter?.sendTelemetryErrorEvent(TelemetryErrorEvent.ACTIVATION, getErrorProperties(error));
   }
 }

--- a/src/packages/config-plugins.ts
+++ b/src/packages/config-plugins.ts
@@ -1,0 +1,36 @@
+/**
+ * Use a bundled version of the Config Plugins mod compiler.
+ * This is used to "compile" or run the plugins on a manifest.
+ *
+ * @TODO Try to use the project's `@expo/config` package, since this could change per SDK version.
+ */
+export { compileModsAsync } from '@expo/config-plugins/build/plugins/mod-compiler';
+
+/**
+ * Reuse the `ModPlatform` type from the Config Plugins package.
+ * This outlines the platforms we can expect from the Config Plugins.
+ */
+export type { ModPlatform } from '@expo/config-plugins/build/Plugin.types';
+
+/**
+ * Use a bundled version of the Gradle properties formatter.
+ * This is used when previewing the project's Gradle properties.
+ */
+export { propertiesListToString as formatGradleProperties } from '@expo/config-plugins/build/android/Properties';
+
+/**
+ * Use a bundled version of the XML formatter.
+ * This is used when previewing XML files within the project.
+ */
+export { format as formatXml } from '@expo/config-plugins/build/utils/XML';
+
+/**
+ * Use a bundled version of the Config Plugins resolver.
+ * This is used when validating the project's app manifest.
+ *
+ * @TODO Try to use the project's `@expo/config` package, since this could change per SDK version.
+ */
+export {
+  resolveConfigPluginFunction,
+  resolveConfigPluginFunctionWithInfo,
+} from '@expo/config-plugins/build/utils/plugin-resolver';

--- a/src/packages/config-plugins.ts
+++ b/src/packages/config-plugins.ts
@@ -1,3 +1,6 @@
+import { loadModuleFromProject } from '../utils/module';
+import { TelemetryErrorEvent, withErrorTelemetry } from '../utils/telemetry';
+
 /* eslint-disable import/first,import/order */
 
 /**
@@ -35,6 +38,22 @@ import { compileModsAsync } from '@expo/config-plugins/build/plugins/mod-compile
 export function loadConfigPluginsModCompiler(projectRoot: string): {
   compileModsAsync: typeof compileModsAsync;
 } {
+  const module = withErrorTelemetry(TelemetryErrorEvent.MODULE_RESOLUTION, () =>
+    loadModuleFromProject<typeof import('@expo/config-plugins/build/plugins/mod-compiler')>(
+      projectRoot,
+      ['expo', '@expo/config-plugins'],
+      'build/plugins/mod-compiler'
+    )
+  );
+
+  if (module) {
+    return module;
+  }
+
+  console.warn(
+    `Falling back to bundled version of '@expo/config-plugins/build/plugins/mod-compiler'`
+  );
+
   return { compileModsAsync };
 }
 
@@ -50,21 +69,28 @@ import {
 } from '@expo/config-plugins/build/utils/plugin-resolver';
 
 /**
- * Use the project's `@expo/config-plugin` plugin resolver (without info), or fallback to the bundled one.
+ * Use the project's `@expo/config-plugin` plugin resolver, or fallback to the bundled one.
  * The bundled one is an older version and will likely have less functionality.
  */
 export function loadConfigPluginsResolver(projectRoot: string): {
   resolveConfigPluginFunction: typeof resolveConfigPluginFunction;
-} {
-  return { resolveConfigPluginFunction };
-}
-
-/**
- * Use the project's `@expo/config-plugin` plugin resolver (with info), or fallback to the bundled one.
- * The bundled one is an older version and will likely have less functionality.
- */
-export function loadConfigPluginsInfoResolver(projectRoot: string): {
   resolveConfigPluginFunctionWithInfo: typeof resolveConfigPluginFunctionWithInfo;
 } {
-  return { resolveConfigPluginFunctionWithInfo };
+  const module = withErrorTelemetry(TelemetryErrorEvent.MODULE_RESOLUTION, () =>
+    loadModuleFromProject<typeof import('@expo/config-plugins/build/utils/plugin-resolver')>(
+      projectRoot,
+      ['expo', '@expo/config-plugins'],
+      'build/utils/plugin-resolver'
+    )
+  );
+
+  if (module) {
+    return module;
+  }
+
+  console.warn(
+    `Falling back to bundled version of '@expo/config-plugins/build/utils/plugin-resolver'`
+  );
+
+  return { resolveConfigPluginFunction, resolveConfigPluginFunctionWithInfo };
 }

--- a/src/packages/config-plugins.ts
+++ b/src/packages/config-plugins.ts
@@ -1,10 +1,4 @@
-/**
- * Use a bundled version of the Config Plugins mod compiler.
- * This is used to "compile" or run the plugins on a manifest.
- *
- * @TODO Try to use the project's `@expo/config` package, since this could change per SDK version.
- */
-export { compileModsAsync } from '@expo/config-plugins/build/plugins/mod-compiler';
+/* eslint-disable import/first,import/order */
 
 /**
  * Reuse the `ModPlatform` type from the Config Plugins package.
@@ -15,22 +9,62 @@ export type { ModPlatform } from '@expo/config-plugins/build/Plugin.types';
 /**
  * Use a bundled version of the Gradle properties formatter.
  * This is used when previewing the project's Gradle properties.
+ * The library itself likely won't change much, so it's safe to only rely on the bundled version.
  */
 export { propertiesListToString as formatGradleProperties } from '@expo/config-plugins/build/android/Properties';
 
 /**
  * Use a bundled version of the XML formatter.
  * This is used when previewing XML files within the project.
+ * The library itself likely won't change much, so it's safe to only rely on the bundled version.
  */
 export { format as formatXml } from '@expo/config-plugins/build/utils/XML';
+
+/**
+ * Use a bundled version of the Config Plugins mod compiler.
+ * This is used to "compile" or run the plugins on a manifest.
+ *
+ * @note This can get out of date and should be loaded from the project where possible.
+ */
+import { compileModsAsync } from '@expo/config-plugins/build/plugins/mod-compiler';
+
+/**
+ * Use the project's `@expo/config-plugin` mod compiler, or fallback to the bundled one.
+ * The bundled one is an older version and will likely have less functionality.
+ */
+export function loadConfigPluginsModCompiler(projectRoot: string): {
+  compileModsAsync: typeof compileModsAsync;
+} {
+  return { compileModsAsync };
+}
 
 /**
  * Use a bundled version of the Config Plugins resolver.
  * This is used when validating the project's app manifest.
  *
- * @TODO Try to use the project's `@expo/config` package, since this could change per SDK version.
+ * @note This can get out of date and should be loaded from the project where possible.
  */
-export {
+import {
   resolveConfigPluginFunction,
   resolveConfigPluginFunctionWithInfo,
 } from '@expo/config-plugins/build/utils/plugin-resolver';
+
+/**
+ * Use the project's `@expo/config-plugin` plugin resolver (without info), or fallback to the bundled one.
+ * The bundled one is an older version and will likely have less functionality.
+ */
+export function loadConfigPluginsResolver(projectRoot: string): {
+  resolveConfigPluginFunction: typeof resolveConfigPluginFunction;
+} {
+  return { resolveConfigPluginFunction };
+}
+
+/**
+ * Use the project's `@expo/config-plugin` plugin resolver (with info), or fallback to the bundled one.
+ * The bundled one is an older version and will likely have less functionality.
+ */
+export function loadConfigPluginsInfoResolver(projectRoot: string): {
+  resolveConfigPluginFunctionWithInfo: typeof resolveConfigPluginFunctionWithInfo;
+} {
+  return { resolveConfigPluginFunctionWithInfo };
+}

--- a/src/packages/config.ts
+++ b/src/packages/config.ts
@@ -1,3 +1,6 @@
+import { loadModuleFromProject } from '../utils/module';
+import { TelemetryErrorEvent, withErrorTelemetry } from '../utils/telemetry';
+
 /* eslint-disable import/first,import/order */
 
 /**
@@ -13,5 +16,19 @@ import { getConfig } from '@expo/config/build/Config';
  * The bundled one is an older version and will likely have less functionality.
  */
 export function loadConfig(projectRoot: string): { getConfig: typeof getConfig } {
+  const module = withErrorTelemetry(TelemetryErrorEvent.MODULE_RESOLUTION, () =>
+    loadModuleFromProject<typeof import('@expo/config/build/Config')>(
+      projectRoot,
+      ['expo', '@expo/config'],
+      'build/Config'
+    )
+  );
+
+  if (module) {
+    return module;
+  }
+
+  console.warn(`Falling back to bundled version of '@expo/config/build/Config'`);
+
   return { getConfig };
 }

--- a/src/packages/config.ts
+++ b/src/packages/config.ts
@@ -1,7 +1,17 @@
+/* eslint-disable import/first,import/order */
+
 /**
  * Use a bundled version of the Expo Config package.
  * This is used to retrieve the app manifest from a project.
  *
- * @TODO Try to use the project's `@expo/config` package, since this could change per SDK version.
+ * @note This can get out of date and should be loaded from the project where possible.
  */
-export { getConfig } from '@expo/config/build/Config';
+import { getConfig } from '@expo/config/build/Config';
+
+/**
+ * Use the project's `@expo/config` loader, or fallback to the bundled one.
+ * The bundled one is an older version and will likely have less functionality.
+ */
+export function loadConfig(projectRoot: string): { getConfig: typeof getConfig } {
+  return { getConfig };
+}

--- a/src/packages/config.ts
+++ b/src/packages/config.ts
@@ -1,0 +1,7 @@
+/**
+ * Use a bundled version of the Expo Config package.
+ * This is used to retrieve the app manifest from a project.
+ *
+ * @TODO Try to use the project's `@expo/config` package, since this could change per SDK version.
+ */
+export { getConfig } from '@expo/config/build/Config';

--- a/src/packages/plist.ts
+++ b/src/packages/plist.ts
@@ -1,0 +1,6 @@
+/**
+ * Use a bundled version of the plist formatter.
+ * This is used when previewing iOS plist files within the project.
+ */
+import plist from '@expo/plist';
+export const formatPlist = plist.build;

--- a/src/packages/plist.ts
+++ b/src/packages/plist.ts
@@ -1,6 +1,9 @@
+/* eslint-disable import/first,import/order */
+
 /**
  * Use a bundled version of the plist formatter.
  * This is used when previewing iOS plist files within the project.
+ * The library itself likely won't change much, so it's safe to only rely on the bundled version.
  */
 import plist from '@expo/plist';
 export const formatPlist = plist.build;

--- a/src/packages/prebuild-config.ts
+++ b/src/packages/prebuild-config.ts
@@ -1,5 +1,19 @@
+/* eslint-disable import/first,import/order */
+
 /**
  * Use a bundled version of the prebuild config generator.
  * This is used to retrieve the config for Config Plugins.
+ *
+ * @note This can get out of date and should be loaded from the project where possible.
  */
-export { getPrebuildConfigAsync } from '@expo/prebuild-config/build/getPrebuildConfig';
+import { getPrebuildConfigAsync } from '@expo/prebuild-config/build/getPrebuildConfig';
+
+/**
+ * Use the project's `@expo/prebuild-config/build/getPrebuildConfig` loader, or fallback to the bundled one.
+ * The bundled one is an older version and will likely have less functionality.
+ */
+export function loadPrebuildConfig(projectRoot: string): {
+  getPrebuildConfigAsync: typeof getPrebuildConfigAsync;
+} {
+  return { getPrebuildConfigAsync };
+}

--- a/src/packages/prebuild-config.ts
+++ b/src/packages/prebuild-config.ts
@@ -22,7 +22,7 @@ export function loadPrebuildConfig(projectRoot: string): {
     loadModuleFromProject<typeof import('@expo/prebuild-config/build/getPrebuildConfig')>(
       projectRoot,
       ['expo', '@expo/cli', '@expo/prebuild-config'],
-      'build/Config'
+      'build/getPrebuildConfig'
     )
   );
 

--- a/src/packages/prebuild-config.ts
+++ b/src/packages/prebuild-config.ts
@@ -1,0 +1,5 @@
+/**
+ * Use a bundled version of the prebuild config generator.
+ * This is used to retrieve the config for Config Plugins.
+ */
+export { getPrebuildConfigAsync } from '@expo/prebuild-config/build/getPrebuildConfig';

--- a/src/packages/prebuild-config.ts
+++ b/src/packages/prebuild-config.ts
@@ -1,3 +1,6 @@
+import { loadModuleFromProject } from '../utils/module';
+import { TelemetryErrorEvent, withErrorTelemetry } from '../utils/telemetry';
+
 /* eslint-disable import/first,import/order */
 
 /**
@@ -15,5 +18,21 @@ import { getPrebuildConfigAsync } from '@expo/prebuild-config/build/getPrebuildC
 export function loadPrebuildConfig(projectRoot: string): {
   getPrebuildConfigAsync: typeof getPrebuildConfigAsync;
 } {
+  const module = withErrorTelemetry(TelemetryErrorEvent.MODULE_RESOLUTION, () =>
+    loadModuleFromProject<typeof import('@expo/prebuild-config/build/getPrebuildConfig')>(
+      projectRoot,
+      ['expo', '@expo/cli', '@expo/prebuild-config'],
+      'build/Config'
+    )
+  );
+
+  if (module) {
+    return module;
+  }
+
+  console.warn(
+    `Falling back to bundled version of '@expo/prebuild-config/build/getPrebuildConfig'`
+  );
+
   return { getPrebuildConfigAsync };
 }

--- a/src/preview/CodeProvider.ts
+++ b/src/preview/CodeProvider.ts
@@ -1,10 +1,9 @@
-import { propertiesListToString as formatAndroidProperties } from '@expo/config-plugins/build/android/Properties';
-import { format as formatXml } from '@expo/config-plugins/build/utils/XML';
-import plist from '@expo/plist';
-import * as path from 'path';
-import * as vscode from 'vscode';
+import path from 'path';
+import vscode from 'vscode';
 
 import { getProjectRoot } from '../expo/project';
+import { formatGradleProperties, formatXml } from '../packages/config-plugins';
+import { formatPlist } from '../packages/plist';
 import { debug } from '../utils/debug';
 import { resetModulesFrom } from '../utils/module';
 
@@ -118,9 +117,9 @@ export class CodeProvider implements vscode.TextDocumentContentProvider {
         return formatXml(results);
       case 'plist':
       case 'entitlements':
-        return plist.build(results);
+        return formatPlist(results);
       case 'properties':
-        return formatAndroidProperties(results);
+        return formatGradleProperties(results);
       default:
         throw new Error('Unknown language: ' + language);
     }

--- a/src/preview/CodeProvider.ts
+++ b/src/preview/CodeProvider.ts
@@ -1,4 +1,5 @@
-import { AndroidConfig, XML } from '@expo/config-plugins';
+import { propertiesListToString as formatAndroidProperties } from '@expo/config-plugins/build/android/Properties';
+import { format as formatXml } from '@expo/config-plugins/build/utils/XML';
 import plist from '@expo/plist';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -114,12 +115,12 @@ export class CodeProvider implements vscode.TextDocumentContentProvider {
       case 'json':
         return JSON.stringify(results, null, 2);
       case 'xml':
-        return XML.format(results);
+        return formatXml(results);
       case 'plist':
       case 'entitlements':
         return plist.build(results);
       case 'properties':
-        return AndroidConfig.Properties.propertiesListToString(results);
+        return formatAndroidProperties(results);
       default:
         throw new Error('Unknown language: ' + language);
     }

--- a/src/preview/ExpoConfigCodeProvider.ts
+++ b/src/preview/ExpoConfigCodeProvider.ts
@@ -1,10 +1,10 @@
-import { getConfig } from '@expo/config';
-import { compileModsAsync } from '@expo/config-plugins';
-import { getPrebuildConfigAsync } from '@expo/prebuild-config';
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 
 import { CodeProvider, BasicCodeProviderOptions, CodeProviderLanguage } from './CodeProvider';
 import { ExpoConfigType } from './constants';
+import { getConfig } from '../packages/config';
+import { compileModsAsync } from '../packages/config-plugins';
+import { getPrebuildConfigAsync } from '../packages/prebuild-config';
 
 export class ExpoConfigCodeProvider extends CodeProvider {
   readonly defaultLanguage: CodeProviderLanguage = 'json';

--- a/src/preview/ExpoConfigCodeProvider.ts
+++ b/src/preview/ExpoConfigCodeProvider.ts
@@ -2,9 +2,9 @@ import vscode from 'vscode';
 
 import { CodeProvider, BasicCodeProviderOptions, CodeProviderLanguage } from './CodeProvider';
 import { ExpoConfigType } from './constants';
-import { getConfig } from '../packages/config';
-import { compileModsAsync } from '../packages/config-plugins';
-import { getPrebuildConfigAsync } from '../packages/prebuild-config';
+import { loadConfig } from '../packages/config';
+import { loadConfigPluginsModCompiler } from '../packages/config-plugins';
+import { loadPrebuildConfig } from '../packages/prebuild-config';
 
 export class ExpoConfigCodeProvider extends CodeProvider {
   readonly defaultLanguage: CodeProviderLanguage = 'json';
@@ -39,12 +39,14 @@ export class IntrospectExpoConfigCodeProvider extends ExpoConfigCodeProvider {
   }
 
   async getExpoConfigAsync() {
+    const { getPrebuildConfigAsync } = loadPrebuildConfig(this.projectRoot);
     return await getPrebuildConfigAsync(this.projectRoot, { platforms: ['ios', 'android'] }).then(
       (config) => config.exp
     );
   }
 
   async getFileContents() {
+    const { compileModsAsync } = loadConfigPluginsModCompiler(this.projectRoot);
     const config = await this.getExpoConfigAsync();
     return await compileModsAsync(config, {
       projectRoot: this.projectRoot,
@@ -60,6 +62,7 @@ export class PublicExpoConfigCodeProvider extends ExpoConfigCodeProvider {
   }
 
   getExpoConfigAsync() {
+    const { getConfig } = loadConfig(this.projectRoot);
     return Promise.resolve(
       getConfig(this.projectRoot, {
         isPublicConfig: true,
@@ -75,6 +78,7 @@ export class PrebuildExpoConfigCodeProvider extends ExpoConfigCodeProvider {
   }
 
   async getExpoConfigAsync() {
+    const { getPrebuildConfigAsync } = loadPrebuildConfig(this.projectRoot);
     return await getPrebuildConfigAsync(this.projectRoot, { platforms: ['ios', 'android'] }).then(
       (config) => config.exp
     );

--- a/src/preview/IntrospectCodeProvider.ts
+++ b/src/preview/IntrospectCodeProvider.ts
@@ -2,8 +2,8 @@ import assert from 'assert';
 import vscode from 'vscode';
 
 import { BasicCodeProviderOptions, CodeProvider, CodeProviderLanguage } from './CodeProvider';
-import { type ModPlatform, compileModsAsync } from '../packages/config-plugins';
-import { getPrebuildConfigAsync } from '../packages/prebuild-config';
+import { type ModPlatform, loadConfigPluginsModCompiler } from '../packages/config-plugins';
+import { loadPrebuildConfig } from '../packages/prebuild-config';
 
 class IntrospectCodeProvider extends CodeProvider {
   getModName(): string {
@@ -22,12 +22,14 @@ class IntrospectCodeProvider extends CodeProvider {
   }
 
   async getExpoConfigAsync() {
+    const { getPrebuildConfigAsync } = loadPrebuildConfig(this.projectRoot);
     return await getPrebuildConfigAsync(this.projectRoot, {
       platforms: [this.getModPlatform()],
     }).then((config) => config.exp);
   }
 
   async getFileContents() {
+    const { compileModsAsync } = loadConfigPluginsModCompiler(this.projectRoot);
     const config = await compileModsAsync(await this.getExpoConfigAsync(), {
       projectRoot: this.projectRoot,
       introspect: true,

--- a/src/preview/IntrospectCodeProvider.ts
+++ b/src/preview/IntrospectCodeProvider.ts
@@ -1,9 +1,9 @@
-import { compileModsAsync, ModPlatform } from '@expo/config-plugins';
-import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 import assert from 'assert';
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 
 import { BasicCodeProviderOptions, CodeProvider, CodeProviderLanguage } from './CodeProvider';
+import { type ModPlatform, compileModsAsync } from '../packages/config-plugins';
+import { getPrebuildConfigAsync } from '../packages/prebuild-config';
 
 class IntrospectCodeProvider extends CodeProvider {
   getModName(): string {

--- a/src/preview/setupPreview.ts
+++ b/src/preview/setupPreview.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 
 import { CodeProvider } from './CodeProvider';
 import {

--- a/src/utils/module.ts
+++ b/src/utils/module.ts
@@ -86,7 +86,7 @@ export function loadModuleFromProject<T extends any>(
       );
     } catch (error) {
       if (error.code === 'MODULE_NOT_FOUND') {
-        const currentChain = dependencies.slice(0, index + 1).join(' → ');
+        const currentChain = dependencies.join(' → ');
         error.message = `Cannot find module '${dependency}/package.json' (${currentChain})`;
       }
 

--- a/src/utils/module.ts
+++ b/src/utils/module.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 /**
  * Reset a single resolved module from the cache registry.
  */
@@ -57,4 +59,52 @@ export function resetModulesFrom(dir: string) {
   }
 
   return cachedIds;
+}
+
+/**
+ * Load a module, through a chain of dependencies, from the project root.
+ * This will attempt to load a module from the user's project.
+ * When it fails, it will warn and return `undefined`.
+ *
+ * There are two types of error messages that can be thrown, both using `MODULE_NOT_FOUND` error codes:
+ *   - Cannot find module '@expo/config-plugins/package.json' (expo → @expo/config-plugins)
+ *   - Cannot find module '@expo/config-plugins/non-existing/file', but did find '@expo/config-plugins'
+ */
+export function loadModuleFromProject<T extends any>(
+  projectRoot: string,
+  dependencies: string[],
+  nestedFile?: string
+): T {
+  // Resolve the dependency chain, using the `<dependency>/package.json` files.
+  // This allows us to use `path.dirname` to get to the root of the dependency.
+  const dependencyPath = dependencies.reduce((currentFile, dependency, index) => {
+    try {
+      return path.dirname(
+        require.resolve(path.join(dependency, 'package.json'), { paths: [currentFile] })
+      );
+    } catch (error) {
+      if (error.code === 'MODULE_NOT_FOUND') {
+        const currentChain = dependencies.slice(0, index + 1).join(' → ');
+        error.message = `Cannot find module '${dependency}/package.json' (${currentChain})`;
+      }
+
+      throw error;
+    }
+  }, projectRoot);
+
+  // Append possibly nested imports to the found dependency path
+  const dependencyImport = nestedFile ? path.join(dependencyPath, nestedFile) : dependencyPath;
+
+  // Try to load the required file or module from the dependency
+  try {
+    return require(/* webpackIgnore: true */ dependencyImport);
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      const currentDependency = path.basename(path.dirname(dependencyPath));
+      const currentDependencyFile = path.join(currentDependency, nestedFile || '');
+      error.message = `Cannot find module '${currentDependencyFile}', but did find '${currentDependency}'`;
+    }
+
+    throw error;
+  }
 }

--- a/src/utils/module.ts
+++ b/src/utils/module.ts
@@ -80,7 +80,9 @@ export function loadModuleFromProject<T extends any>(
   const dependencyPath = dependencies.reduce((currentFile, dependency, index) => {
     try {
       return path.dirname(
-        require.resolve(path.join(dependency, 'package.json'), { paths: [currentFile] })
+        require.resolve(/* webpackIgnore: true */ path.join(dependency, 'package.json'), {
+          paths: [currentFile],
+        })
       );
     } catch (error) {
       if (error.code === 'MODULE_NOT_FOUND') {


### PR DESCRIPTION
### Linked issue
We need to decouple the dependence on `@expo/*` package a bit. This is the first step.