### PR TITLE
refactor: emphasize bundled `@expo/*` packages and limit imports

### DIFF
--- a/src/__tests__/commands/code-provider.e2e.ts
+++ b/src/__tests__/commands/code-provider.e2e.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import * as json from 'jsonc-parser';
+import * as jsonc from 'jsonc-parser';
 import { commands, TextEditor, window } from 'vscode';
 
 import { PreviewCommand, PreviewModProvider } from '../../preview/constants';
@@ -33,7 +33,7 @@ describe('CodeProvider', () => {
     );
 
     const preview = await waitForEditorOpen('AndroidManifest.xml');
-    const addition = json.modify(
+    const addition = jsonc.modify(
       app.document.getText(),
       ['expo', 'updates', 'url'],
       'https://example.com/updates/url',
@@ -43,7 +43,7 @@ describe('CodeProvider', () => {
     const EXPECTED_UPDATES_URL =
       '<meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://example.com/updates/url"/>';
 
-    await replaceEditorContent(app, json.applyEdits(app.document.getText(), addition));
+    await replaceEditorContent(app, jsonc.applyEdits(app.document.getText(), addition));
     await app.document.save();
 
     const includesChange = await waitForTrue(
@@ -52,11 +52,11 @@ describe('CodeProvider', () => {
 
     expect(includesChange).to.equal(true);
 
-    const removal = json.modify(app.document.getText(), ['expo', 'updates'], undefined, {
+    const removal = jsonc.modify(app.document.getText(), ['expo', 'updates'], undefined, {
       formattingOptions: { insertSpaces: true },
     });
 
-    await replaceEditorContent(app, json.applyEdits(app.document.getText(), removal));
+    await replaceEditorContent(app, jsonc.applyEdits(app.document.getText(), removal));
     await app.document.save();
 
     const excludesChange = await waitForFalse(

--- a/src/expo/plugin.ts
+++ b/src/expo/plugin.ts
@@ -1,10 +1,10 @@
-import {
-  resolveConfigPluginFunction,
-  resolveConfigPluginFunctionWithInfo,
-} from '@expo/config-plugins/build/utils/plugin-resolver';
 import { findNodeAtLocation, getNodeValue, Node, Range } from 'jsonc-parser';
 
 import { ExpoProject } from './project';
+import {
+  resolveConfigPluginFunction,
+  resolveConfigPluginFunctionWithInfo,
+} from '../packages/config-plugins';
 import { truthy } from '../utils/array';
 import { resetModuleFrom } from '../utils/module';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 
 import { ExpoProjectCache } from './expo/project';
 import { ExpoDebuggersProvider } from './expoDebuggers';

--- a/src/packages/config-plugins.ts
+++ b/src/packages/config-plugins.ts
@@ -1,0 +1,40 @@
+/* eslint-disable import/first,import/order */
+
+/**
+ * Reuse the `ModPlatform` type from the Config Plugins package.
+ * This outlines the platforms we can expect from the Config Plugins.
+ */
+export type { ModPlatform } from '@expo/config-plugins/build/Plugin.types';
+
+/**
+ * Use a bundled version of the Gradle properties formatter.
+ * This is used when previewing the project's Gradle properties.
+ * The library itself likely won't change much, so it's safe to only rely on the bundled version.
+ */
+export { propertiesListToString as formatGradleProperties } from '@expo/config-plugins/build/android/Properties';
+
+/**
+ * Use a bundled version of the XML formatter.
+ * This is used when previewing XML files within the project.
+ * The library itself likely won't change much, so it's safe to only rely on the bundled version.
+ */
+export { format as formatXml } from '@expo/config-plugins/build/utils/XML';
+
+/**
+ * Use a bundled version of the Config Plugins mod compiler.
+ * This is used to "compile" or run the plugins on a manifest.
+ *
+ * @note This bundled package is slightly outdated, attempt to load from `npx expo config` instead.
+ */
+export { compileModsAsync } from '@expo/config-plugins/build/plugins/mod-compiler';
+
+/**
+ * Use a bundled version of the Config Plugins resolver.
+ * This is used when validating the project's app manifest.
+ *
+ * @note This bundled package is slightly outdated and should be loaded from the project where possible.
+ */
+export {
+  resolveConfigPluginFunction,
+  resolveConfigPluginFunctionWithInfo,
+} from '@expo/config-plugins/build/utils/plugin-resolver';

--- a/src/packages/config.ts
+++ b/src/packages/config.ts
@@ -1,0 +1,9 @@
+/* eslint-disable import/first,import/order */
+
+/**
+ * Use a bundled version of the Expo Config package.
+ * This is used to retrieve the app manifest from a project.
+ *
+ * @note This bundled package is slightly outdated, attempt to load from `npx expo config` instead.
+ */
+export { type ExpoConfig, getConfig } from '@expo/config/build/Config';

--- a/src/packages/plist.ts
+++ b/src/packages/plist.ts
@@ -1,0 +1,9 @@
+/* eslint-disable import/first,import/order */
+
+/**
+ * Use a bundled version of the plist formatter.
+ * This is used when previewing iOS plist files within the project.
+ * The library itself likely won't change much, so it's safe to only rely on the bundled version.
+ */
+import plist from '@expo/plist';
+export const formatPlist = plist.build;

--- a/src/packages/prebuild-config.ts
+++ b/src/packages/prebuild-config.ts
@@ -1,0 +1,9 @@
+/* eslint-disable import/first,import/order */
+
+/**
+ * Use a bundled version of the prebuild config generator.
+ * This is used to retrieve the config for Config Plugins.
+ *
+ * @note This bundled package is slightly outdated, attempt to load from `npx expo config` instead.
+ */
+export { getPrebuildConfigAsync } from '@expo/prebuild-config/build/getPrebuildConfig';

--- a/src/preview/CodeProvider.ts
+++ b/src/preview/CodeProvider.ts
@@ -1,9 +1,9 @@
-import { AndroidConfig, XML } from '@expo/config-plugins';
-import plist from '@expo/plist';
-import * as path from 'path';
-import * as vscode from 'vscode';
+import path from 'path';
+import vscode from 'vscode';
 
 import { getProjectRoot } from '../expo/project';
+import { formatGradleProperties, formatXml } from '../packages/config-plugins';
+import { formatPlist } from '../packages/plist';
 import { debug } from '../utils/debug';
 import { resetModulesFrom } from '../utils/module';
 
@@ -114,12 +114,12 @@ export class CodeProvider implements vscode.TextDocumentContentProvider {
       case 'json':
         return JSON.stringify(results, null, 2);
       case 'xml':
-        return XML.format(results);
+        return formatXml(results);
       case 'plist':
       case 'entitlements':
-        return plist.build(results);
+        return formatPlist(results);
       case 'properties':
-        return AndroidConfig.Properties.propertiesListToString(results);
+        return formatGradleProperties(results);
       default:
         throw new Error('Unknown language: ' + language);
     }

--- a/src/preview/ExpoConfigCodeProvider.ts
+++ b/src/preview/ExpoConfigCodeProvider.ts
@@ -1,10 +1,10 @@
-import { getConfig } from '@expo/config';
-import { compileModsAsync } from '@expo/config-plugins';
-import { getPrebuildConfigAsync } from '@expo/prebuild-config';
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 
 import { CodeProvider, BasicCodeProviderOptions, CodeProviderLanguage } from './CodeProvider';
 import { ExpoConfigType } from './constants';
+import { getConfig } from '../packages/config';
+import { compileModsAsync } from '../packages/config-plugins';
+import { getPrebuildConfigAsync } from '../packages/prebuild-config';
 
 export class ExpoConfigCodeProvider extends CodeProvider {
   readonly defaultLanguage: CodeProviderLanguage = 'json';

--- a/src/preview/IntrospectCodeProvider.ts
+++ b/src/preview/IntrospectCodeProvider.ts
@@ -1,9 +1,9 @@
-import { compileModsAsync, ModPlatform } from '@expo/config-plugins';
-import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 import assert from 'assert';
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 
 import { BasicCodeProviderOptions, CodeProvider, CodeProviderLanguage } from './CodeProvider';
+import { compileModsAsync, type ModPlatform } from '../packages/config-plugins';
+import { getPrebuildConfigAsync } from '../packages/prebuild-config';
 
 class IntrospectCodeProvider extends CodeProvider {
   getModName(): string {

--- a/src/preview/setupPreview.ts
+++ b/src/preview/setupPreview.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 
 import { CodeProvider } from './CodeProvider';
 import {


### PR DESCRIPTION
### Linked issue
Supersedes #216

We need to decouple the dependence on @expo/* package a bit. This is the first step.