### PR TITLE
fix: add `userAgent` query parameter in debugger

### DIFF
--- a/src/expoDebuggers.ts
+++ b/src/expoDebuggers.ts
@@ -10,11 +10,13 @@ import {
 import { ExpoProjectCache, ExpoProject, findProjectFromWorkspaces } from './expo/project';
 import { debug } from './utils/debug';
 import { featureTelemetry } from './utils/telemetry';
+import { version as extensionVersion } from '../package.json';
 
 const log = debug.extend('expo-debuggers');
 
 const DEBUG_TYPE = 'expo';
 const DEBUG_COMMAND = 'expo.debug.start';
+const DEBUG_USER_AGENT = `vscode/${vscode.version} vscode-expo-tools/${extensionVersion}`;
 
 interface ExpoDebugConfig extends vscode.DebugConfiguration {
   projectRoot: string;
@@ -198,7 +200,10 @@ async function resolveDeviceConfig(config: ExpoDebugConfig, project: ExpoProject
     workflow: device._workflow,
 
     // The address of the device to connect to
-    websocketAddress: `${device.webSocketDebuggerUrl}&type=vscode`,
+    websocketAddress:
+      device.webSocketDebuggerUrl +
+      '&type=vscode' + // Adding the "classic" `type=vscode` query parameter (SDK <=49)
+      `&userAgent=${encodeURIComponent(DEBUG_USER_AGENT)}`, // Adding the modern "userAgent" query parameter (SDK >=50)s
 
     // Define the required root paths to resolve source maps
     localRoot: project.root,

--- a/src/expoDebuggers.ts
+++ b/src/expoDebuggers.ts
@@ -203,7 +203,7 @@ async function resolveDeviceConfig(config: ExpoDebugConfig, project: ExpoProject
     websocketAddress:
       device.webSocketDebuggerUrl +
       '&type=vscode' + // Adding the "classic" `type=vscode` query parameter (SDK <=49)
-      `&userAgent=${encodeURIComponent(DEBUG_USER_AGENT)}`, // Adding the modern "userAgent" query parameter (SDK >=50)s
+      `&userAgent=${encodeURIComponent(DEBUG_USER_AGENT)}`, // Adding the modern "userAgent" query parameter (SDK >=50)
 
     // Define the required root paths to resolve source maps
     localRoot: project.root,


### PR DESCRIPTION
### Linked issue
See PR expo/expo#25649, specifically [this line](https://github.com/expo/expo/pull/25649/files#diff-8be445febc4537dfa7db7961c4d7f60ad9e1af9ada0cb99db9cfba1d3b54f788R106)

### Additional context
VSCode doesn't send any `User-Agent` headers when connecting through web sockets. This differs from the Chrome DevTools, where we can safely detect this Chrome-based debugger. Since we have some workarounds for known React Native CDP (as opposed to the future Hermes CDP) implementation.

### TODO
- Test this once a `canary` release is available with expo/expo#25649