### PR TITLE
chore: bump minimal required vscode version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/picomatch": "^2.3.3",
         "@types/sinon": "^10.0.16",
         "@types/sinon-chai": "^3.2.12",
-        "@types/vscode": "^1.78.2",
+        "@types/vscode": "^1.86.0",
         "@vscode/test-electron": "^2.3.9",
         "@vscode/vsce": "^2.21.0",
         "arg": "^5.0.2",
@@ -68,7 +68,7 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "vscode": "^1.78.0"
+        "vscode": "^1.86.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3366,9 +3366,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.81.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.81.0.tgz",
-      "integrity": "sha512-YIaCwpT+O2E7WOMq0eCgBEABE++SX3Yl/O02GoMIF2DO3qAtvw7m6BXFYsxnc6XyzwZgh6/s/UG78LSSombl2w==",
+      "version": "1.87.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.87.0.tgz",
+      "integrity": "sha512-y3yYJV2esWr8LNjp3VNbSMWG7Y43jC8pCldG8YwiHGAQbsymkkMMt0aDT1xZIOFM2eFcNiUc+dJMx1+Z0UT8fg==",
       "dev": true
     },
     "node_modules/@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/picomatch": "^2.3.3",
     "@types/sinon": "^10.0.16",
     "@types/sinon-chai": "^3.2.12",
-    "@types/vscode": "^1.78.2",
+    "@types/vscode": "^1.86.0",
     "@vscode/test-electron": "^2.3.9",
     "@vscode/vsce": "^2.21.0",
     "arg": "^5.0.2",
@@ -98,7 +98,7 @@
   "publisher": "expo",
   "icon": "images/logo-marketplace.png",
   "engines": {
-    "vscode": "^1.78.0"
+    "vscode": "^1.86.0"
   },
   "categories": [
     "Debuggers",


### PR DESCRIPTION
### Linked issue
This is required because of the debugger-related bug from https://github.com/expo/vscode-expo/pull/245

If you are reading this, ensure you are at least on vscode `1.86.0+`.
