### PR TITLE
feature: use `vscode.workspace.fs` API to load Expo projects

### DIFF
--- a/src/expo/__tests__/project.test.ts
+++ b/src/expo/__tests__/project.test.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import { findNodeAtLocation } from 'jsonc-parser';
+import vscode from 'vscode';
+
+import { ExpoProjectCache, findProjectFromWorkspaces } from '../project';
+import { readWorkspaceFile, relativeUri } from '../../utils/file';
+
+describe('ExpoProjectCache', () => {
+  it('adds disposable to extension context', () => {
+    const subscriptions: any[] = [];
+    using _projects = stubProjectCache(subscriptions);
+
+    expect(subscriptions).to.have.length(1);
+  });
+});
+
+describe('findProjectFromWorkspaces', () => {
+  it('returns projct from workspace using relative path', () => {
+    using projects = stubProjectCache();
+    const project = findProjectFromWorkspaces(projects, './manifest');
+
+    expect(project).to.exist;
+  });
+
+  it('returned project contains parsed package file', () => {
+    using projects = stubProjectCache();
+    const project = findProjectFromWorkspaces(projects, './manifest');
+
+    expect(project?.package.tree).to.exist;
+    expect(findNodeAtLocation(project!.package.tree, ['name'])!.value).to.equal('manifest');
+  });
+
+  it('returned project contains parsed expo manifest file', () => {
+    using projects = stubProjectCache();
+    const project = findProjectFromWorkspaces(projects, './manifest');
+
+    expect(project?.manifest!.tree).to.exist;
+    expect(findNodeAtLocation(project!.manifest!.tree, ['name'])!.value).to.equal('manifest');
+  });
+});
+
+describe('ExpoProject', () => {
+  it('returns expo version from package file', async () => {
+    using projects = stubProjectCache();
+
+    const project = findProjectFromWorkspaces(projects, './manifest');
+    const workspace = vscode.workspace.workspaceFolders![0];
+    const packageUri = relativeUri(workspace.uri, 'manifest/package.json');
+    const packageFile = JSON.parse(await readWorkspaceFile(packageUri));
+
+    expect(project?.expoVersion).to.equal(packageFile.dependencies.expo);
+  });
+});
+
+function stubProjectCache(subscriptions: vscode.ExtensionContext['subscriptions'] = []) {
+  const stubProjectCache = new ExpoProjectCache({ subscriptions });
+
+  // @ts-expect-error
+  stubProjectCache[Symbol.dispose] = () => stubProjectCache.dispose();
+
+  return stubProjectCache as Disposable & typeof stubProjectCache;
+}

--- a/src/expo/__tests__/project.test.ts
+++ b/src/expo/__tests__/project.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { findNodeAtLocation } from 'jsonc-parser';
 import vscode from 'vscode';
 
-import { readWorkspaceFile, relativeUri } from '../../utils/file';
+import { readWorkspaceFile } from '../../utils/file';
 import { ExpoProjectCache, findProjectFromWorkspaces } from '../project';
 
 describe('ExpoProjectCache', () => {
@@ -45,7 +45,7 @@ describe('ExpoProject', () => {
 
     const project = await findProjectFromWorkspaces(projects, './manifest');
     const workspace = vscode.workspace.workspaceFolders![0];
-    const packageUri = relativeUri(workspace.uri, 'manifest/package.json');
+    const packageUri = vscode.Uri.joinPath(workspace.uri, 'manifest', 'package.json');
     const packageFile = JSON.parse(await readWorkspaceFile(packageUri));
 
     expect(project?.expoVersion).to.equal(packageFile.dependencies.expo);

--- a/src/expo/__tests__/project.test.ts
+++ b/src/expo/__tests__/project.test.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import { findNodeAtLocation } from 'jsonc-parser';
 import vscode from 'vscode';
 
-import { ExpoProjectCache, findProjectFromWorkspaces } from '../project';
 import { readWorkspaceFile, relativeUri } from '../../utils/file';
+import { ExpoProjectCache, findProjectFromWorkspaces } from '../project';
 
 describe('ExpoProjectCache', () => {
   it('adds disposable to extension context', () => {
@@ -22,17 +22,17 @@ describe('findProjectFromWorkspaces', () => {
     expect(project).to.exist;
   });
 
-  it('returned project contains parsed package file', () => {
+  it('returned project contains parsed package file', async () => {
     using projects = stubProjectCache();
-    const project = findProjectFromWorkspaces(projects, './manifest');
+    const project = await findProjectFromWorkspaces(projects, './manifest');
 
     expect(project?.package.tree).to.exist;
     expect(findNodeAtLocation(project!.package.tree, ['name'])!.value).to.equal('manifest');
   });
 
-  it('returned project contains parsed expo manifest file', () => {
+  it('returned project contains parsed expo manifest file', async () => {
     using projects = stubProjectCache();
-    const project = findProjectFromWorkspaces(projects, './manifest');
+    const project = await findProjectFromWorkspaces(projects, './manifest');
 
     expect(project?.manifest!.tree).to.exist;
     expect(findNodeAtLocation(project!.manifest!.tree, ['name'])!.value).to.equal('manifest');
@@ -43,7 +43,7 @@ describe('ExpoProject', () => {
   it('returns expo version from package file', async () => {
     using projects = stubProjectCache();
 
-    const project = findProjectFromWorkspaces(projects, './manifest');
+    const project = await findProjectFromWorkspaces(projects, './manifest');
     const workspace = vscode.workspace.workspaceFolders![0];
     const packageUri = relativeUri(workspace.uri, 'manifest/package.json');
     const packageFile = JSON.parse(await readWorkspaceFile(packageUri));

--- a/src/expo/plugin.ts
+++ b/src/expo/plugin.ts
@@ -81,5 +81,5 @@ export function resolveInstalledPluginInfo(
   if (search) dependencies = dependencies.filter((name) => name.startsWith(search));
   if (maxResults !== null) dependencies = dependencies.slice(0, maxResults);
 
-  return dependencies.map((name) => resolvePluginInfo(project.root, name)).filter(truthy);
+  return dependencies.map((name) => resolvePluginInfo(project.root.fsPath, name)).filter(truthy);
 }

--- a/src/expo/project.ts
+++ b/src/expo/project.ts
@@ -5,7 +5,7 @@ import vscode from 'vscode';
 
 import { MapCacheProvider } from '../utils/cache';
 import { debug } from '../utils/debug';
-import { readWorkspaceFile, relativeUri } from '../utils/file';
+import { readWorkspaceFile } from '../utils/file';
 
 const log = debug.extend('project');
 
@@ -43,7 +43,7 @@ export function findProjectFromWorkspace(
   relativePath?: string
 ) {
   return relativePath
-    ? projects.fromRoot(relativeUri(workspace.uri, relativePath))
+    ? projects.fromRoot(vscode.Uri.joinPath(workspace.uri, relativePath))
     : projects.fromRoot(workspace.uri);
 }
 
@@ -74,7 +74,7 @@ export class ExpoProjectCache extends MapCacheProvider<ExpoProject> {
       return this.cache.get(cacheKey);
     }
 
-    const packagePath = relativeUri(projectPath, 'package.json');
+    const packagePath = vscode.Uri.joinPath(projectPath, 'package.json');
 
     // Ensure the project has a `package.json` file
     const packageInfo = await vscode.workspace.fs.stat(packagePath);
@@ -92,7 +92,7 @@ export class ExpoProjectCache extends MapCacheProvider<ExpoProject> {
 
     // Load the `app.json` or `app.config.json` file, if available
     for (const appFileName of ['app.json', 'app.config.json']) {
-      const filePath = relativeUri(projectPath, appFileName);
+      const filePath = vscode.Uri.joinPath(projectPath, appFileName);
       const fileStat = await vscode.workspace.fs.stat(filePath);
       if (fileStat.type === vscode.FileType.File) {
         project.setManifest(await readWorkspaceFile(filePath));

--- a/src/expo/project.ts
+++ b/src/expo/project.ts
@@ -97,6 +97,20 @@ export class ExpoProjectCache extends MapCacheProvider<ExpoProject> {
     }
 
     const project = new ExpoProject(root, packageFile);
+
+    // Check if there is a `app.json` or `app.config.json` file
+    const hasAppJson = fs.existsSync(path.join(root, 'app.json'));
+    const hasAppConfigJson = fs.existsSync(path.join(root, 'app.config.json'));
+
+    if (hasAppJson || hasAppConfigJson) {
+      project.setManifest(
+        fs.readFileSync(
+          hasAppJson ? path.join(root, 'app.json') : path.join(root, 'app.config.json'),
+          'utf-8'
+        )
+      );
+    }
+
     this.cache.set(root, project);
     return project;
   }
@@ -117,6 +131,11 @@ export class ExpoProject {
 
   get manifest() {
     return this.manifestFile;
+  }
+
+  get expoVersion() {
+    const version = jsonc.findNodeAtLocation(this.packageFile.tree, ['dependencies', 'expo']);
+    return version?.type === 'string' ? version.value : undefined;
   }
 
   setPackage(content: string) {

--- a/src/expoDebuggers.ts
+++ b/src/expoDebuggers.ts
@@ -7,7 +7,12 @@ import {
   inferDevicePlatform,
   fetchDevicesToInspectFromUnknownWorkflow,
 } from './expo/bundler';
-import { ExpoProjectCache, ExpoProject, findProjectFromWorkspaces } from './expo/project';
+import {
+  ExpoProjectCache,
+  ExpoProject,
+  findProjectFromWorkspaces,
+  findProjectFromWorkspace,
+} from './expo/project';
 import { debug } from './utils/debug';
 import { featureTelemetry } from './utils/telemetry';
 import { version as extensionVersion } from '../package.json';
@@ -47,7 +52,7 @@ export class ExpoDebuggersProvider implements vscode.DebugConfigurationProvider 
   }
 
   async onDebugCommand() {
-    let project = findProjectFromWorkspaces(this.projects);
+    let project = await findProjectFromWorkspaces(this.projects);
     let projectRelativePath: string | undefined = '';
 
     if (!project) {
@@ -63,7 +68,7 @@ export class ExpoDebuggersProvider implements vscode.DebugConfigurationProvider 
         return log('No relative project path entered, aborting...');
       }
 
-      project = findProjectFromWorkspaces(this.projects, projectRelativePath);
+      project = await findProjectFromWorkspaces(this.projects, projectRelativePath);
     }
 
     if (!project) {
@@ -75,7 +80,7 @@ export class ExpoDebuggersProvider implements vscode.DebugConfigurationProvider 
       );
     }
 
-    log('Resolved dynamic project configuration for:', project.root);
+    log('Resolved dynamic project configuration for:', project.root.fsPath);
     featureTelemetry('command', DEBUG_COMMAND, {
       path: projectRelativePath ? 'nested' : 'workspace',
     });
@@ -84,12 +89,17 @@ export class ExpoDebuggersProvider implements vscode.DebugConfigurationProvider 
       type: DEBUG_TYPE,
       request: 'attach',
       name: 'Inspect Expo app',
-      projectRoot: project.root,
+      projectRoot: project.root.fsPath,
     });
   }
 
-  provideDebugConfigurations(workspace?: vscode.WorkspaceFolder, token?: vscode.CancellationToken) {
-    const project = findProjectFromWorkspaces(this.projects);
+  async provideDebugConfigurations(
+    workspace?: vscode.WorkspaceFolder,
+    token?: vscode.CancellationToken
+  ) {
+    const project = workspace
+      ? await findProjectFromWorkspace(this.projects, workspace)
+      : await findProjectFromWorkspaces(this.projects);
 
     return [
       {
@@ -155,7 +165,7 @@ export class ExpoDebuggersProvider implements vscode.DebugConfigurationProvider 
     config: ExpoDebugConfig,
     token?: vscode.CancellationToken
   ) {
-    const project = this.projects.maybeFromRoot(config.projectRoot);
+    const project = await this.projects.fromRoot(vscode.Uri.file(config.projectRoot));
 
     if (!project) {
       featureTelemetry('debugger', `${DEBUG_TYPE}/aborted`, { reason: 'no-project' });

--- a/src/expoDebuggers.ts
+++ b/src/expoDebuggers.ts
@@ -185,7 +185,7 @@ export class ExpoDebuggersProvider implements vscode.DebugConfigurationProvider 
     // Resolve the target device config to inspect
     const { platform, ...deviceConfig } = await resolveDeviceConfig(config, project);
 
-    featureTelemetry('debugger', `${DEBUG_TYPE}`, { platform });
+    featureTelemetry('debugger', `${DEBUG_TYPE}`, { platform, expoVersion: project.expoVersion });
 
     return { ...config, ...deviceConfig };
   }

--- a/src/manifestAssetCompletions.ts
+++ b/src/manifestAssetCompletions.ts
@@ -10,7 +10,7 @@ import {
 } from './settings';
 import { truthy } from './utils/array';
 import { debug } from './utils/debug';
-import { fileIsExcluded, fileIsHidden, getDirectoryPath, relativeUri } from './utils/file';
+import { fileIsExcluded, fileIsHidden, getDirectoryPath } from './utils/file';
 import { findKeyStringNode, getDocumentRange, isKeyNode } from './utils/json';
 import { ExpoCompletionsProvider, withCancelToken } from './utils/vscode';
 
@@ -75,7 +75,7 @@ export class ManifestAssetCompletionsProvider extends ExpoCompletionsProvider {
     // Search entities within the user-provided directory
     const positionDir = getDirectoryPath(positionValue) ?? '';
     const entities = await withCancelToken(token, () =>
-      vscode.workspace.fs.readDirectory(relativeUri(project.root, positionDir))
+      vscode.workspace.fs.readDirectory(vscode.Uri.joinPath(project.root, positionDir))
     );
 
     return entities

--- a/src/manifestAssetCompletions.ts
+++ b/src/manifestAssetCompletions.ts
@@ -10,7 +10,7 @@ import {
 } from './settings';
 import { truthy } from './utils/array';
 import { debug } from './utils/debug';
-import { fileIsExcluded, fileIsHidden, getDirectoryPath } from './utils/file';
+import { fileIsExcluded, fileIsHidden, getDirectoryPath, relativeUri } from './utils/file';
 import { findKeyStringNode, getDocumentRange, isKeyNode } from './utils/json';
 import { ExpoCompletionsProvider, withCancelToken } from './utils/vscode';
 
@@ -47,7 +47,7 @@ export class ManifestAssetCompletionsProvider extends ExpoCompletionsProvider {
   ) {
     if (!this.isEnabled) return null;
 
-    const project = this.projects.fromManifest(document);
+    const project = await this.projects.fromManifest(document);
     if (!project?.manifest) {
       log('Could not resolve project from manifest "%s"', document.fileName);
       return [];
@@ -75,7 +75,7 @@ export class ManifestAssetCompletionsProvider extends ExpoCompletionsProvider {
     // Search entities within the user-provided directory
     const positionDir = getDirectoryPath(positionValue) ?? '';
     const entities = await withCancelToken(token, () =>
-      vscode.workspace.fs.readDirectory(vscode.Uri.file(path.join(project.root, positionDir)))
+      vscode.workspace.fs.readDirectory(relativeUri(project.root, positionDir))
     );
 
     return entities

--- a/src/manifestDiagnostics.ts
+++ b/src/manifestDiagnostics.ts
@@ -6,7 +6,6 @@ import { getPluginDefinition, resolvePluginFunctionUnsafe } from './expo/plugin'
 import { ExpoProject, ExpoProjectCache } from './expo/project';
 import { isManifestPluginValidationEnabled } from './settings';
 import { debug } from './utils/debug';
-import { relativeUri } from './utils/file';
 import { getDocumentRange } from './utils/json';
 import { resetModuleFrom } from './utils/module';
 import { ExpoDiagnosticsProvider } from './utils/vscode';
@@ -115,7 +114,7 @@ async function diagnoseAsset(
   reference: FileReference
 ) {
   try {
-    const uri = relativeUri(project.root, reference.filePath);
+    const uri = vscode.Uri.joinPath(project.root, reference.filePath);
     const asset = await vscode.workspace.fs.stat(uri);
 
     if (asset.type === vscode.FileType.Directory) {

--- a/src/manifestLinks.ts
+++ b/src/manifestLinks.ts
@@ -26,12 +26,12 @@ export class ManifestLinksProvider extends ExpoLinkProvider {
     );
   }
 
-  provideDocumentLinks(document: vscode.TextDocument, token: vscode.CancellationToken) {
+  async provideDocumentLinks(document: vscode.TextDocument, token: vscode.CancellationToken) {
     const links: vscode.DocumentLink[] = [];
 
     if (!this.isEnabled) return links;
 
-    const project = this.projects.fromManifest(document);
+    const project = await this.projects.fromManifest(document);
     if (!project?.manifest) {
       log('Could not resolve project from manifest "%s"', document.fileName);
       return links;
@@ -45,7 +45,7 @@ export class ManifestLinksProvider extends ExpoLinkProvider {
       if (token.isCancellationRequested) return links;
 
       const { nameValue, nameRange } = getPluginDefinition(pluginNode);
-      const plugin = resolvePluginInfo(project.root, nameValue);
+      const plugin = resolvePluginInfo(project.root.fsPath, nameValue);
 
       if (plugin) {
         const link = new vscode.DocumentLink(
@@ -65,7 +65,7 @@ export class ManifestLinksProvider extends ExpoLinkProvider {
       const range = getDocumentRange(document, reference.fileRange);
 
       if (!pluginsRange?.contains(range)) {
-        const file = path.resolve(project.root, reference.filePath);
+        const file = path.resolve(project.root.fsPath, reference.filePath);
         const link = new vscode.DocumentLink(range, vscode.Uri.file(file));
 
         link.tooltip = 'Go to asset';

--- a/src/manifestPluginCompletions.ts
+++ b/src/manifestPluginCompletions.ts
@@ -11,7 +11,7 @@ import {
 } from './settings';
 import { truthy } from './utils/array';
 import { debug } from './utils/debug';
-import { fileIsExcluded, fileIsHidden, getDirectoryPath, relativeUri } from './utils/file';
+import { fileIsExcluded, fileIsHidden, getDirectoryPath } from './utils/file';
 import { getDocumentRange, isKeyNode } from './utils/json';
 import { ExpoCompletionsProvider, withCancelToken } from './utils/vscode';
 
@@ -76,7 +76,7 @@ export class ManifestPluginCompletionsProvider extends ExpoCompletionsProvider {
     if (positionIsPath && !token.isCancellationRequested) {
       const positionDir = getDirectoryPath(positionValue) ?? '';
       const entities = await withCancelToken(token, () =>
-        vscode.workspace.fs.readDirectory(relativeUri(project.root, positionDir))
+        vscode.workspace.fs.readDirectory(vscode.Uri.joinPath(project.root, positionDir))
       );
 
       return entities

--- a/src/utils/__tests__/file.test.ts
+++ b/src/utils/__tests__/file.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
-import vscode from 'vscode';
 
-import { fileIsExcluded, fileIsHidden, getDirectoryPath, relativeUri } from '../file';
+import { fileIsExcluded, fileIsHidden, getDirectoryPath } from '../file';
 
 describe('getDirectoryPath', () => {
   it('returns root (.) for paths without directories', () => {
@@ -47,19 +46,5 @@ describe('fileIsExcluded', () => {
     expect(fileIsExcluded('App.tsx', { 'App.js': true })).to.be.false;
     expect(fileIsExcluded('my-app/package.json', { '**/App.js': true })).to.be.false;
     expect(fileIsExcluded('my-app/package.json', { '**/package.json': false })).to.be.false;
-  });
-});
-
-describe('relativeUri', () => {
-  it('returns new uri instance', () => {
-    const oldUri = vscode.Uri.parse('file:///old/uri');
-    const newUri = relativeUri(oldUri, 'new/uri');
-
-    expect(newUri).to.not.equal(oldUri);
-  });
-
-  it('returns uri with relative path', () => {
-    const uri = relativeUri(vscode.Uri.parse('file:///old/uri'), 'new/uri');
-    expect(uri.path).to.equal('/old/uri/new/uri');
   });
 });

--- a/src/utils/__tests__/file.test.ts
+++ b/src/utils/__tests__/file.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
+import vscode from 'vscode';
 
-import { fileIsExcluded, fileIsHidden, getDirectoryPath } from '../file';
+import { fileIsExcluded, fileIsHidden, getDirectoryPath, relativeUri } from '../file';
 
 describe('getDirectoryPath', () => {
   it('returns root (.) for paths without directories', () => {
@@ -46,5 +47,19 @@ describe('fileIsExcluded', () => {
     expect(fileIsExcluded('App.tsx', { 'App.js': true })).to.be.false;
     expect(fileIsExcluded('my-app/package.json', { '**/App.js': true })).to.be.false;
     expect(fileIsExcluded('my-app/package.json', { '**/package.json': false })).to.be.false;
+  });
+});
+
+describe('relativeUri', () => {
+  it('returns new uri instance', () => {
+    const oldUri = vscode.Uri.parse('file:///old/uri');
+    const newUri = relativeUri(oldUri, 'new/uri');
+
+    expect(newUri).to.not.equal(oldUri);
+  });
+
+  it('returns uri with relative path', () => {
+    const uri = relativeUri(vscode.Uri.parse('file:///old/uri'), 'new/uri');
+    expect(uri.path).to.equal('/old/uri/new/uri');
   });
 });

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -3,7 +3,7 @@ import { Disposable, ExtensionContext } from 'vscode';
 export abstract class MapCacheProvider<V, K = string> implements Disposable {
   protected cache: Map<K, V> = new Map();
 
-  constructor({ subscriptions }: ExtensionContext) {
+  constructor({ subscriptions }: Pick<ExtensionContext, 'subscriptions'>) {
     subscriptions.push(this);
   }
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -39,8 +39,3 @@ export function fileIsExcluded(filePath: string, filesExcluded?: Record<string, 
 export async function readWorkspaceFile(uri: vscode.Uri) {
   return Buffer.from(await vscode.workspace.fs.readFile(uri)).toString('utf-8');
 }
-
-/** Create a new relative URI from existing URI */
-export function relativeUri(uri: vscode.Uri, relativePath: string) {
-  return uri.with({ path: path.posix.join(uri.path, relativePath) });
-}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import picomatch from 'picomatch';
+import vscode from 'vscode';
 
 /**
  * Get the directory path from a user-provided file path.
@@ -32,4 +33,14 @@ export function fileIsExcluded(filePath: string, filesExcluded?: Record<string, 
   return Object.entries(filesExcluded).some(
     ([pattern, isExcluded]) => isExcluded && picomatch(pattern)(filePath)
   );
+}
+
+/** Read a workspace file through vscode's workspace API and return the string equivalent */
+export async function readWorkspaceFile(uri: vscode.Uri) {
+  return Buffer.from(await vscode.workspace.fs.readFile(uri)).toString('utf-8');
+}
+
+/** Create a new relative URI from existing URI */
+export function relativeUri(uri: vscode.Uri, relativePath: string) {
+  return uri.with({ path: path.join(uri.path, relativePath) });
 }

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -42,5 +42,5 @@ export async function readWorkspaceFile(uri: vscode.Uri) {
 
 /** Create a new relative URI from existing URI */
 export function relativeUri(uri: vscode.Uri, relativePath: string) {
-  return uri.with({ path: path.join(uri.path, relativePath) });
+  return uri.with({ path: path.posix.join(uri.path, relativePath) });
 }


### PR DESCRIPTION
### Linked issue
We already used most of the `vscode.workspace.fs` API, but not to load Expo projects. That still happened through `fs.` calls. This fully removes all `fs.` calls when loading Expo projects.
