### PR TITLE
chore: enable tests for vscode insiders versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        vscode: [oldest, stable]
+        vscode: [oldest, stable, insiders]
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4


### PR DESCRIPTION
### Linked issue
This should pro-actively warn us about vscode API changes.
