### PR TITLE
fix: activate extension after startup is finished

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "ms-vscode.js-debug"
   ],
   "activationEvents": [
+    "onStartupFinished",
     "workspaceContains:node_modules/expo",
     "onDebug",
     "onDebugResolve:expo",


### PR DESCRIPTION
### Linked issue
This is because `workspaceContains:node_modules/expo` doesnt work for non-top-level references.

See: https://github.com/Microsoft/vscode/issues/2739