### PR TITLE
fix: use optional chaining when validating relative paths in manifest asset completions

### DIFF
--- a/src/manifestAssetCompletions.ts
+++ b/src/manifestAssetCompletions.ts
@@ -70,7 +70,7 @@ export class ManifestAssetCompletionsProvider extends ExpoCompletionsProvider {
 
     // Abort if the path is not relative, or if there is an extension already
     const positionValue = getNodeValue(positionNode);
-    if (!positionValue || !positionValue.startsWith('.') || path.extname(positionValue)) {
+    if (!positionValue?.startsWith('.') || path.extname(positionValue)) {
       return null;
     }
 


### PR DESCRIPTION
### Linked issue
This is being reported as an unhandled promise error. This should solve that.

![image](https://github.com/expo/vscode-expo/assets/1203991/c9b66241-0197-4ac5-86e1-8850d96c8d40)
