### PR TITLE
feature: add more infers to determine device platform when debugging

### DIFF
--- a/src/expo/__tests__/bundler.test.ts
+++ b/src/expo/__tests__/bundler.test.ts
@@ -7,6 +7,7 @@ import {
   fetchDevicesToInspect,
   fetchDevicesToInspectFromUnknownWorkflow,
   findDeviceByName,
+  inferDevicePlatform,
 } from '../bundler';
 
 const host = '127.0.0.2';
@@ -117,5 +118,30 @@ describe('findDeviceByName', () => {
     ];
 
     expect(findDeviceByName(devices, 'iPhone 15 Pro')).to.equal(target);
+  });
+});
+
+describe('inferDevicePlatform', () => {
+  it('returns ios for standard simulator device names', () => {
+    expect(inferDevicePlatform({ deviceName: 'iPhone 15 pro' })).to.equal('ios');
+    expect(inferDevicePlatform({ deviceName: 'iPhone 12 mini' })).to.equal('ios');
+    expect(inferDevicePlatform({ deviceName: 'iPhone 15' })).to.equal('ios');
+    expect(inferDevicePlatform({ deviceName: 'iPad Air' })).to.equal('ios');
+    expect(inferDevicePlatform({ deviceName: 'iPad mini' })).to.equal('ios');
+    expect(inferDevicePlatform({ deviceName: 'iPadPro 12.9"' })).to.equal('ios');
+  });
+
+  it('returns android for standard emulator device names', () => {
+    expect(inferDevicePlatform({ deviceName: 'sdk_gphone64_arm64' })).to.equal('android');
+    expect(inferDevicePlatform({ deviceName: 'Pixel 8 API 31' })).to.equal('android');
+  });
+
+  it('returns windows for standard Windows desktop device names', () => {
+    expect(inferDevicePlatform({ deviceName: 'Cedrics-Desktop' })).to.equal('windows');
+    expect(inferDevicePlatform({ deviceName: 'Windows 10' })).to.equal('windows');
+  });
+
+  it('returns macos for standard MacOS device names', () => {
+    expect(inferDevicePlatform({ deviceName: 'Cedric’s MacBook Pro' })).to.equal('macos');
   });
 });

--- a/src/expo/bundler.ts
+++ b/src/expo/bundler.ts
@@ -80,12 +80,19 @@ export async function askDeviceByName(devices: InspectableDevice[]) {
 }
 
 /** Try to infer the device platform, by device name */
-export function inferDevicePlatform(device: InspectableDevice) {
+export function inferDevicePlatform(device: Pick<InspectableDevice, 'deviceName'>) {
   const name = device.deviceName?.toLowerCase();
   if (!name) return null;
   if (name.includes('iphone')) return 'ios';
+  if (name.includes('ipad')) return 'ios';
   if (name.includes('gphone')) return 'android';
   if (name.includes('desktop')) return 'windows';
   if (name.includes('mac')) return 'macos';
+
+  // Android usually adds `XXX API 31` to the device name
+  if (name.match(/api\s+[0-9]+/)) return 'android';
+  // Windows might include the windows name
+  if (name.includes('windows')) return 'windows';
+
   return null;
 }


### PR DESCRIPTION
### Linked issue
It's not ideal, but it should cover more cases. We need to know on what platform issues occur, so we can fix them.