### PR TITLE
fix(bundler): Device filtering in SDK 53

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-expo-tools",
-  "version": "1.4.3",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-expo-tools",
-      "version": "1.4.3",
+      "version": "1.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/expo/__tests__/bundler.test.ts
+++ b/src/expo/__tests__/bundler.test.ts
@@ -14,7 +14,6 @@ describe('fetchDevicesToInspect', () => {
     expect(fetch).to.have.been.calledWith(`http://${host}:${port}/json/list`);
   });
 
-  // TODO: find out why the stubbing isnt working for this fetch
   it('filters by page id', async () => {
     const mockDeviceWithNativePageReloads = (device) =>
       mockDevice({

--- a/src/expo/__tests__/bundler.test.ts
+++ b/src/expo/__tests__/bundler.test.ts
@@ -15,27 +15,60 @@ describe('fetchDevicesToInspect', () => {
   });
 
   // TODO: find out why the stubbing isnt working for this fetch
-  xit('filters by page id', async () => {
-    using _fetch = stubFetch([
+  it('filters by page id', async () => {
+    const mockDeviceWithNativePageReloads = (device) =>
       mockDevice({
+        ...device,
+        reactNative: {
+          ...device.reactNative,
+          capabilities: {
+            nativePageReloads: true,
+            ...device.reactNative?.capabilities,
+          },
+        },
+      });
+
+    using _fetch = stubFetch([
+      // SDK 52
+      mockDeviceWithNativePageReloads({
         title: 'React Native Bridgeless [C++ connection]',
         deviceName: 'iPhone 15 Pro',
         webSocketDebuggerUrl: 'ws://localhost:8081/inspector/device?page=1',
       }),
-      mockDevice({
+      mockDeviceWithNativePageReloads({
         title: 'React Native Bridgeless [C++ connection]',
         deviceName: 'iPhone 15 Pro',
         webSocketDebuggerUrl: 'ws://localhost:8081/inspector/device?page=2',
+      }),
+      // SDK 53+
+      mockDeviceWithNativePageReloads({
+        title: 'com.expo.app (iPhone 16 Pro)',
+        description: 'React Native Bridgeless [C++ connection]',
+        deviceName: 'iPhone 16 Pro',
+        webSocketDebuggerUrl: 'ws://localhost:8082/inspector/device?page=1',
+      }),
+      mockDeviceWithNativePageReloads({
+        title: 'com.expo.app (iPhone 16 Pro)',
+        description: 'React Native Bridgeless [C++ connection]',
+        deviceName: 'iPhone 16 Pro',
+        webSocketDebuggerUrl: 'ws://localhost:8082/inspector/device?page=2',
       }),
     ]);
 
     const devices = await fetchDevicesToInspect({ host, port });
 
-    expect(devices).to.have.length(1);
+    expect(devices).to.have.length(2);
     expect(devices).to.deep.equal([
-      mockDevice({
+      mockDeviceWithNativePageReloads({
+        title: 'React Native Bridgeless [C++ connection]',
         deviceName: 'iPhone 15 Pro',
         webSocketDebuggerUrl: 'ws://localhost:8081/inspector/device?page=2',
+      }),
+      mockDeviceWithNativePageReloads({
+        title: 'com.expo.app (iPhone 16 Pro)',
+        description: 'React Native Bridgeless [C++ connection]',
+        deviceName: 'iPhone 16 Pro',
+        webSocketDebuggerUrl: 'ws://localhost:8082/inspector/device?page=2',
       }),
     ]);
   });

--- a/src/expo/__tests__/bundler.test.ts
+++ b/src/expo/__tests__/bundler.test.ts
@@ -15,18 +15,6 @@ describe('fetchDevicesToInspect', () => {
   });
 
   it('filters by page id', async () => {
-    const mockDeviceWithNativePageReloads = (device) =>
-      mockDevice({
-        ...device,
-        reactNative: {
-          ...device.reactNative,
-          capabilities: {
-            nativePageReloads: true,
-            ...device.reactNative?.capabilities,
-          },
-        },
-      });
-
     using _fetch = stubFetch([
       // SDK 52
       mockDeviceWithNativePageReloads({
@@ -71,6 +59,36 @@ describe('fetchDevicesToInspect', () => {
       }),
     ]);
   });
+
+  it('filters reanimated ui', async () => {
+    using _fetch = stubFetch([
+      // SDK 53+
+      mockDeviceWithNativePageReloads({
+        title: 'com.expo.app (iPhone 16 Pro)',
+        description: 'React Native Bridgeless [C++ connection]',
+        deviceName: 'iPhone 16 Pro',
+        webSocketDebuggerUrl: 'ws://localhost:8082/inspector/device?page=1',
+      }),
+      mockDeviceWithNativePageReloads({
+        title: 'com.expo.app (iPhone 16 Pro)',
+        description: 'Reanimated UI runtime [C++ connection]',
+        deviceName: 'iPhone 16 Pro',
+        webSocketDebuggerUrl: 'ws://localhost:8082/inspector/device?page=2',
+      }),
+    ]);
+
+    const devices = await fetchDevicesToInspect({ host, port });
+
+    expect(devices).to.have.length(1);
+    expect(devices).to.deep.equal([
+      mockDeviceWithNativePageReloads({
+        title: 'com.expo.app (iPhone 16 Pro)',
+        description: 'React Native Bridgeless [C++ connection]',
+        deviceName: 'iPhone 16 Pro',
+        webSocketDebuggerUrl: 'ws://localhost:8082/inspector/device?page=1',
+      }),
+    ]);
+  });
 });
 
 describe('findDeviceByName', () => {
@@ -111,3 +129,15 @@ describe('inferDevicePlatform', () => {
     expect(inferDevicePlatform({ deviceName: 'Cedric’s MacBook Pro' })).to.equal('macos');
   });
 });
+
+const mockDeviceWithNativePageReloads = (device) =>
+  mockDevice({
+    ...device,
+    reactNative: {
+      ...device.reactNative,
+      capabilities: {
+        nativePageReloads: true,
+        ...device.reactNative?.capabilities,
+      },
+    },
+  });

--- a/src/expo/__tests__/bundler.test.ts
+++ b/src/expo/__tests__/bundler.test.ts
@@ -130,7 +130,7 @@ describe('inferDevicePlatform', () => {
   });
 });
 
-const mockDeviceWithNativePageReloads = (device) =>
+const mockDeviceWithNativePageReloads = (device: Record<string, any>) =>
   mockDevice({
     ...device,
     reactNative: {

--- a/src/expo/bundler.ts
+++ b/src/expo/bundler.ts
@@ -5,6 +5,7 @@ import { truthy } from '../utils/array';
 
 const INSPECTABLE_DEVICE_TITLE = 'React Native Experimental (Improved Chrome Reloads)';
 const REACT_NATIVE_BRIDGELESS_CDP_RUNTIME = 'React Native Bridgeless [C++ connection]';
+const REANIMATED_UI_CDP_RUNTIME = 'Reanimated UI runtime [C++ connection]';
 
 export interface InspectableDevice {
   id: string;
@@ -50,7 +51,8 @@ export async function fetchDevicesToInspect({
   const reloadable = devices.filter(
     (device) =>
       device.title === INSPECTABLE_DEVICE_TITLE || // SDK <51
-      device.reactNative?.capabilities?.nativePageReloads // SDK 52+
+      device.reactNative?.capabilities?.nativePageReloads || // SDK 52+
+      device.description !== REANIMATED_UI_CDP_RUNTIME // SDK 53+
   );
 
   // Manual filter for Expo Go, we really need to fix this

--- a/src/expo/bundler.ts
+++ b/src/expo/bundler.ts
@@ -50,9 +50,9 @@ export async function fetchDevicesToInspect({
   const devices = (await response.json()) as InspectableDevice[];
   const reloadable = devices.filter(
     (device) =>
-      device.title === INSPECTABLE_DEVICE_TITLE || // SDK <51
-      device.reactNative?.capabilities?.nativePageReloads || // SDK 52+
-      device.description !== REANIMATED_UI_CDP_RUNTIME // SDK 53+
+      device.description !== REANIMATED_UI_CDP_RUNTIME && // SDK 53+
+      (device.title === INSPECTABLE_DEVICE_TITLE || // SDK <51
+        device.reactNative?.capabilities?.nativePageReloads) // SDK 52+
   );
 
   // Manual filter for Expo Go, we really need to fix this

--- a/src/expo/bundler.ts
+++ b/src/expo/bundler.ts
@@ -4,6 +4,7 @@ import vscode from 'vscode';
 import { truthy } from '../utils/array';
 
 const INSPECTABLE_DEVICE_TITLE = 'React Native Experimental (Improved Chrome Reloads)';
+const REACT_NATIVE_BRIDGELESS_CDP_RUNTIME = 'React Native Bridgeless [C++ connection]';
 
 export interface InspectableDevice {
   id: string;
@@ -55,7 +56,16 @@ export async function fetchDevicesToInspect({
   // Manual filter for Expo Go, we really need to fix this
   const inspectable = reloadable.filter((device, index, list) => {
     // Only apply this to SDK 52+
-    if (device.title !== 'React Native Bridgeless [C++ connection]') return true;
+    if (
+      ![
+        // SDK 52
+        device.title,
+        // SDK 53+ (https://github.com/expo/expo/commit/f545f30fe1df3dd0d346b12aa65a2feb7cb27439)
+        device.description,
+      ].includes(REACT_NATIVE_BRIDGELESS_CDP_RUNTIME)
+    )
+      return true;
+
     // If there are multiple inspectable pages, only use highest page number
     const devicesByPageNumber = list
       .filter((other) => device.title === other.title)


### PR DESCRIPTION
### Linked issue
Provide the issue(s) which this pull request relates to or fixes.

- fixes: https://github.com/expo/vscode-expo/issues/271

### Additional context
Are there things the maintainers should be aware of before merging or closing this pull request?

This PR fixes:
- Version misalignment in the lock file
- Expo Go filtering test
- Expo Go filtering after https://github.com/expo/expo/commit/f545f30fe1df3dd0d346b12aa65a2feb7cb27439
- Filter Reanimated UI Inspectable target

<details>
<summary>Details</summary>

Filter out `Reanimated UI runtime`

```
  {
    "id": "027caaae50b565d3dcf71a35ae72343af5381b76-1",
    "title": "com.krystofwoldrich.ToTheMoon (iPhone 16)",
    "description": "React Native Bridgeless [C++ connection]",
    "appId": "com.krystofwoldrich.ToTheMoon",
    "type": "node",
    "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=localhost%3A8081%2Finspector%2Fdebug%3Fdevice%3D027caaae50b565d3dcf71a35ae72343af5381b76%26page%3D1",
    "webSocketDebuggerUrl": "ws://localhost:8081/inspector/debug?device=027caaae50b565d3dcf71a35ae72343af5381b76&page=1",
    "deviceName": "iPhone 16",
    "reactNative": {
      "logicalDeviceId": "027caaae50b565d3dcf71a35ae72343af5381b76",
      "capabilities": {
        "prefersFuseboxFrontend": true,
        "nativeSourceCodeFetching": false,
        "nativePageReloads": true
      }
    }
  },
  {
    "id": "027caaae50b565d3dcf71a35ae72343af5381b76-2",
    "title": "com.krystofwoldrich.ToTheMoon (iPhone 16)",
    "description": "Reanimated UI runtime [C++ connection]",
    "appId": "com.krystofwoldrich.ToTheMoon",
    "type": "node",
    "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=localhost%3A8081%2Finspector%2Fdebug%3Fdevice%3D027caaae50b565d3dcf71a35ae72343af5381b76%26page%3D2",
    "webSocketDebuggerUrl": "ws://localhost:8081/inspector/debug?device=027caaae50b565d3dcf71a35ae72343af5381b76&page=2",
    "deviceName": "iPhone 16",
    "reactNative": {
      "logicalDeviceId": "027caaae50b565d3dcf71a35ae72343af5381b76",
      "capabilities": {
        "prefersFuseboxFrontend": false,
        "nativeSourceCodeFetching": false,
        "nativePageReloads": false
      }
    }
  }
```

</details>

PS.: I'm still having issues with the debugger (missing source maps) after these fixes, but I think that should be solved in different PR. After this PR the plugging connects VSCode to the correct target and the console logs are printed as expected.