### PR TITLE
Add manifest tooling support for app.config.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-expo-tools",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-expo-tools",
-      "version": "1.6.0",
+      "version": "1.6.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19,7 +19,8 @@
         "find-up": "^5.0.0",
         "jsonc-parser": "^3.2.1",
         "node-fetch": "^2.6.7",
-        "picomatch": "^4.0.1"
+        "picomatch": "^4.0.1",
+        "typescript": "^5.4.5"
       },
       "devDependencies": {
         "@expo/config-plugins": "^4.1.5",
@@ -66,7 +67,6 @@
         "sinon": "^18.0.0",
         "sinon-chai": "^3.7.0",
         "sucrase": "^3.35.0",
-        "typescript": "^5.4.5",
         "webpack": "^5.91.0",
         "webpack-cli": "^5.1.4",
         "ws": "^8.17.0"
@@ -16931,7 +16931,6 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "find-up": "^5.0.0",
     "jsonc-parser": "^3.2.1",
     "node-fetch": "^2.6.7",
-    "picomatch": "^4.0.1"
+    "picomatch": "^4.0.1",
+    "typescript": "^5.4.5"
   },
   "devDependencies": {
     "@expo/config-plugins": "^4.1.5",
@@ -94,7 +95,6 @@
     "sinon": "^18.0.0",
     "sinon-chai": "^3.7.0",
     "sucrase": "^3.35.0",
-    "typescript": "^5.4.5",
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4",
     "ws": "^8.17.0"
@@ -167,15 +167,15 @@
           "type": "boolean",
           "default": true,
           "scope": "resource",
-          "description": "Validate the config plugins in app manifests, listed under \"expo.plugins\". This only applies to \"app.json\" and \"app.config.json\" files.",
-          "markdownDescription": "Validate the config plugins in app manifests, listed under `expo.plugins`. This only applies to `app.json` and `app.config.json` files."
+          "description": "Validate the config plugins in app manifests, listed under \"expo.plugins\". This applies to \"app.json\", \"app.config.json\", and object-literal \"app.config.js\" / \"app.config.ts\" files.",
+          "markdownDescription": "Validate the config plugins in app manifests, listed under `expo.plugins`. This applies to `app.json`, `app.config.json`, and object-literal `app.config.js` / `app.config.ts` files."
         },
         "expo.appManifest.fileReferences": {
           "type": "boolean",
           "default": true,
           "scope": "resource",
-          "description": "Enable suggestions for file references in app manifests, like the splash screen. This only applies to \"app.json\" and \"app.config.json\" files.",
-          "markdownDescription": "Enable suggestions for file references in app manifests, like the splash screen This only applies to `app.json` and `app.config.json` files."
+          "description": "Enable suggestions for file references in app manifests, like the splash screen. This applies to \"app.json\", \"app.config.json\", and object-literal \"app.config.js\" / \"app.config.ts\" files.",
+          "markdownDescription": "Enable suggestions for file references in app manifests, like the splash screen. This applies to `app.json`, `app.config.json`, and object-literal `app.config.js` / `app.config.ts` files."
         },
         "expo.appManifest.fileReferences.excludeGlobPatterns": {
           "type": "object",

--- a/src/__tests__/dynamicManifest.e2e.ts
+++ b/src/__tests__/dynamicManifest.e2e.ts
@@ -1,0 +1,228 @@
+import { expect } from 'chai';
+import vscode from 'vscode';
+
+import {
+  closeAllEditors,
+  closeActiveEditor,
+  findContentRange,
+  getWorkspaceUri,
+  replaceEditorContent,
+  waitForActiveTabNameOpen,
+} from './utils/vscode';
+import { waitFor } from './utils/wait';
+import { readWorkspaceFile } from '../utils/file';
+
+describe('dynamic manifests', () => {
+  ['app.config.js', 'app.config.ts'].forEach((manifestFile) => {
+    describe(`manifest: ${manifestFile}`, () => {
+      describe('asset completions', () => {
+        let app: vscode.TextEditor;
+
+        beforeEach(async () => {
+          app = await vscode.window.showTextDocument(getWorkspaceUri('manifest', manifestFile));
+        });
+
+        afterEach(() => closeActiveEditor());
+
+        it('suggests folders from project', async () => {
+          const range = findContentRange(app, './assets/icon.png');
+          await app.edit((builder) => builder.replace(range, './'));
+
+          const suggestions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            app.document.uri,
+            range.start
+          );
+
+          expect(suggestions.items).to.have.length(2);
+          expect(suggestions.items).to.containSubset([{ label: 'assets/' }, { label: 'plugins/' }]);
+        });
+
+        it('suggests image asset files from project', async () => {
+          const range = findContentRange(app, './assets/icon.png');
+          await app.edit((builder) => builder.replace(range, './assets/'));
+
+          const suggestions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            app.document.uri,
+            range.start
+          );
+
+          expect(suggestions.items).to.have.length(4);
+          expect(suggestions.items).to.containSubset([
+            { label: 'adaptive-icon.png' },
+            { label: 'favicon.png' },
+            { label: 'icon.png' },
+            { label: 'splash.png' },
+          ]);
+        });
+      });
+
+      describe('plugin completions', () => {
+        let app: vscode.TextEditor;
+
+        beforeEach(async () => {
+          app = await vscode.window.showTextDocument(getWorkspaceUri('manifest', manifestFile));
+        });
+
+        afterEach(() => closeActiveEditor());
+
+        it('suggests folders from local project', async () => {
+          const range = findContentRange(app, './plugins/valid');
+          await app.edit((builder) => builder.replace(range, './'));
+
+          const suggestions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            app.document.uri,
+            range.start
+          );
+
+          expect(suggestions.items).to.containSubset([
+            { label: 'assets/', command: { command: 'editor.action.triggerSuggest' } },
+            { label: 'plugins/', command: { command: 'editor.action.triggerSuggest' } },
+          ]);
+        });
+
+        it('suggests plugins from local project', async () => {
+          const range = findContentRange(app, './plugins/valid');
+          await app.edit((builder) => builder.replace(range, './plugins/'));
+
+          const suggestions = await vscode.commands.executeCommand<vscode.CompletionList>(
+            'vscode.executeCompletionItemProvider',
+            app.document.uri,
+            range.start
+          );
+
+          expect(suggestions.items).to.containSubset([{ label: 'valid.js' }]);
+        });
+      });
+
+      describe('links', () => {
+        let app: vscode.TextEditor;
+
+        beforeEach(async () => {
+          app = await vscode.window.showTextDocument(getWorkspaceUri('manifest', manifestFile));
+        });
+
+        afterEach(() => closeAllEditors());
+
+        it('opens valid asset link', async () => {
+          const links = await vscode.commands.executeCommand<vscode.DocumentLink[]>(
+            'vscode.executeLinkProvider',
+            app.document.uri
+          );
+
+          const range = findContentRange(app, './assets/icon.png');
+          const link = links.find((item) => item.range.contains(range));
+
+          await vscode.commands.executeCommand('vscode.open', link?.target);
+          expect(await waitForActiveTabNameOpen('icon.png')).to.equal(true);
+        });
+
+        it('opens valid plugin from local file', async () => {
+          const links = await vscode.commands.executeCommand<vscode.DocumentLink[]>(
+            'vscode.executeLinkProvider',
+            app.document.uri
+          );
+
+          const range = findContentRange(app, './plugins/valid');
+          const link = links.find((item) => item.range.contains(range));
+
+          await vscode.commands.executeCommand('vscode.open', link?.target);
+          expect(await waitForActiveTabNameOpen('valid.js')).to.equal(true);
+        });
+      });
+
+      describe('diagnostics', () => {
+        let app: vscode.TextEditor;
+        let content: string;
+
+        before(async () => {
+          content = await readWorkspaceFile(getWorkspaceUri('manifest', manifestFile));
+        });
+
+        beforeEach(async () => {
+          app = await vscode.window.showTextDocument(getWorkspaceUri('manifest', manifestFile));
+        });
+
+        afterEach(() => replaceEditorContent(app, content));
+        after(() => closeAllEditors());
+
+        it('diagnoses non-existing asset file reference', async () => {
+          const range = findContentRange(app, './assets/splash.png');
+          await app.edit((builder) => builder.replace(range, './assets/doesnt-exist.png'));
+          await waitFor(1000);
+
+          const diagnostics = await vscode.languages.getDiagnostics(app.document.uri);
+          expect(diagnostics).to.containSubset([
+            {
+              code: 'FILE_NOT_FOUND',
+              message: 'File not found: ./assets/doesnt-exist.png',
+              severity: vscode.DiagnosticSeverity.Warning,
+            },
+          ]);
+        });
+
+        it('diagnoses asset directory reference', async () => {
+          const range = findContentRange(app, './assets/adaptive-icon.png');
+          await app.edit((builder) => builder.replace(range, './assets'));
+          await waitFor(1000);
+
+          const diagnostics = await vscode.languages.getDiagnostics(app.document.uri);
+          expect(diagnostics).to.containSubset([
+            {
+              code: 'FILE_IS_DIRECTORY',
+              message: 'File is a directory: ./assets',
+              severity: vscode.DiagnosticSeverity.Warning,
+            },
+          ]);
+        });
+
+        it('diagnoses non-existing local plugin definition', async () => {
+          const range = findContentRange(app, './plugins/valid');
+          await app.edit((builder) => builder.replace(range, './plugins/doesnt-exist'));
+          await waitFor(1000);
+
+          const diagnostics = await vscode.languages.getDiagnostics(app.document.uri);
+          expect(diagnostics).to.containSubset([
+            {
+              code: 'PLUGIN_NOT_FOUND',
+              message: 'Plugin not found: ./plugins/doesnt-exist',
+              severity: vscode.DiagnosticSeverity.Warning,
+            },
+          ]);
+        });
+
+        it('diagnoses empty string plugin definition', async () => {
+          const range = findContentRange(app, 'plugins: [');
+          await app.edit((builder) => builder.replace(range, `plugins: ["",`));
+          await waitFor(1000);
+
+          const diagnostics = await vscode.languages.getDiagnostics(app.document.uri);
+          expect(diagnostics).to.containSubset([
+            {
+              code: `PLUGIN_DEFINITION_INVALID`,
+              message: 'Plugin definition is empty, expected a file or dependency name',
+              severity: vscode.DiagnosticSeverity.Warning,
+            },
+          ]);
+        });
+
+        it('diagnoses empty array plugin definition', async () => {
+          const range = findContentRange(app, 'plugins: [');
+          await app.edit((builder) => builder.replace(range, `plugins: [[],`));
+          await waitFor(1000);
+
+          const diagnostics = await vscode.languages.getDiagnostics(app.document.uri);
+          expect(diagnostics).to.containSubset([
+            {
+              code: `PLUGIN_DEFINITION_INVALID`,
+              message: 'Plugin definition is empty, expected a file or dependency name',
+              severity: vscode.DiagnosticSeverity.Warning,
+            },
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/src/expo/__tests__/manifest.test.ts
+++ b/src/expo/__tests__/manifest.test.ts
@@ -2,19 +2,19 @@ import { expect } from 'chai';
 import picomatch from 'picomatch';
 
 import { type ExpoConfig } from '../../packages/config';
-import { manifestPattern, getFileReferences } from '../manifest';
+import { getFileReferences, jsonManifestPattern } from '../manifest';
 
 describe('manifestPattern', () => {
   it('scheme is set to files', () => {
-    expect(manifestPattern.scheme).to.equal('file');
+    expect(jsonManifestPattern.scheme).to.equal('file');
   });
 
   it('language is set to json with comments', () => {
-    expect(manifestPattern.language).to.equal('jsonc');
+    expect(jsonManifestPattern.language).to.equal('jsonc');
   });
 
   it('pattern includes all json variations of the Expo manifest', () => {
-    const pattern = manifestPattern.pattern as string;
+    const pattern = jsonManifestPattern.pattern as string;
     const matcher = picomatch(pattern);
 
     expect(matcher('my-app/app.json')).to.be.true;

--- a/src/expo/dynamicManifest.ts
+++ b/src/expo/dynamicManifest.ts
@@ -1,0 +1,431 @@
+import { Range } from 'jsonc-parser';
+import path from 'path';
+import ts from 'typescript';
+import vscode from 'vscode';
+
+import { getDirectoryPath } from '../utils/file';
+
+export type FileReference = {
+  filePath: string;
+  fileRange: Range;
+};
+
+export type PluginDefinition = {
+  nameValue?: string;
+  nameRange: Range;
+};
+
+export type StringReferenceContext =
+  | {
+      kind: 'asset';
+      keyName: string;
+      value: string;
+    }
+  | {
+      kind: 'plugin';
+      value: string;
+    };
+
+const ASSET_PROPERTIES =
+  /^((?:x?x?x?(?:h|m)dpi)|(tablet|foreground|background)?[iI]mage|(?:fav)?icon)/;
+
+export function getDynamicAssetReferences(document: vscode.TextDocument): FileReference[] {
+  const config = getExpoConfigObject(document);
+  if (!config) {
+    return [];
+  }
+
+  const references: FileReference[] = [];
+  collectAssetReferences(config, references);
+  return references;
+}
+
+export function getDynamicPluginDefinitions(document: vscode.TextDocument): PluginDefinition[] {
+  const config = getExpoConfigObject(document);
+  if (!config) {
+    return [];
+  }
+
+  const plugins = findPropertyAssignment(config, 'plugins');
+  if (!plugins || !ts.isArrayLiteralExpression(plugins.initializer)) {
+    return [];
+  }
+
+  return plugins.initializer.elements.map((element) => getPluginDefinition(element));
+}
+
+export function getDynamicStringReferenceContext(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): StringReferenceContext | undefined {
+  const sourceFile = createSourceFile(document);
+  const offset = document.offsetAt(position);
+  const node = findStringNodeAtOffset(sourceFile, offset);
+  if (!node) {
+    return undefined;
+  }
+
+  const pluginContext = getPluginContext(node);
+  if (pluginContext) {
+    return pluginContext;
+  }
+
+  const assetContext = getAssetContext(node);
+  if (assetContext) {
+    return assetContext;
+  }
+
+  return undefined;
+}
+
+function getExpoConfigObject(
+  document: vscode.TextDocument
+): ts.ObjectLiteralExpression | undefined {
+  const sourceFile = createSourceFile(document);
+  const bindings = collectTopLevelBindings(sourceFile);
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportAssignment(statement)) {
+      const config = extractConfigObjectFromExpression(statement.expression, bindings);
+      if (config) {
+        return normalizeExpoConfigObject(config);
+      }
+    }
+
+    if (ts.isFunctionDeclaration(statement) && hasDefaultExportModifier(statement)) {
+      const config = extractConfigObjectFromFunction(statement, bindings);
+      if (config) {
+        return normalizeExpoConfigObject(config);
+      }
+    }
+
+    if (
+      ts.isExpressionStatement(statement) &&
+      ts.isBinaryExpression(statement.expression) &&
+      statement.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      isModuleExportsExpression(statement.expression.left)
+    ) {
+      const config = extractConfigObjectFromExpression(statement.expression.right, bindings);
+      if (config) {
+        return normalizeExpoConfigObject(config);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function createSourceFile(document: vscode.TextDocument) {
+  return ts.createSourceFile(
+    document.fileName,
+    document.getText(),
+    ts.ScriptTarget.Latest,
+    true,
+    document.fileName.endsWith('.ts') ? ts.ScriptKind.TS : ts.ScriptKind.JS
+  );
+}
+
+function collectTopLevelBindings(sourceFile: ts.SourceFile) {
+  const bindings = new Map<string, ts.Expression | ts.FunctionDeclaration>();
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (
+          ts.isIdentifier(declaration.name) &&
+          declaration.initializer &&
+          (ts.isExpression(declaration.initializer) ||
+            ts.isArrowFunction(declaration.initializer) ||
+            ts.isFunctionExpression(declaration.initializer))
+        ) {
+          bindings.set(declaration.name.text, declaration.initializer);
+        }
+      }
+    }
+
+    if (ts.isFunctionDeclaration(statement) && statement.name) {
+      bindings.set(statement.name.text, statement);
+    }
+  }
+
+  return bindings;
+}
+
+function extractConfigObjectFromExpression(
+  expression: ts.Expression,
+  bindings: Map<string, ts.Expression | ts.FunctionDeclaration>
+): ts.ObjectLiteralExpression | undefined {
+  if (ts.isParenthesizedExpression(expression)) {
+    return extractConfigObjectFromExpression(expression.expression, bindings);
+  }
+
+  if (ts.isObjectLiteralExpression(expression)) {
+    return expression;
+  }
+
+  if (ts.isIdentifier(expression)) {
+    const resolved = bindings.get(expression.text);
+    if (resolved) {
+      return ts.isFunctionDeclaration(resolved)
+        ? extractConfigObjectFromFunction(resolved, bindings)
+        : extractConfigObjectFromExpression(resolved, bindings);
+    }
+  }
+
+  if (ts.isArrowFunction(expression) || ts.isFunctionExpression(expression)) {
+    return extractConfigObjectFromFunction(expression, bindings);
+  }
+
+  return undefined;
+}
+
+function extractConfigObjectFromFunction(
+  declaration: ts.FunctionDeclaration | ts.FunctionExpression | ts.ArrowFunction,
+  bindings: Map<string, ts.Expression | ts.FunctionDeclaration>
+): ts.ObjectLiteralExpression | undefined {
+  if (!declaration.body) {
+    return undefined;
+  }
+
+  if (ts.isObjectLiteralExpression(declaration.body)) {
+    return declaration.body;
+  }
+
+  if (!ts.isBlock(declaration.body)) {
+    return undefined;
+  }
+
+  for (const statement of declaration.body.statements) {
+    if (ts.isReturnStatement(statement) && statement.expression) {
+      return extractConfigObjectFromExpression(statement.expression, bindings);
+    }
+  }
+
+  return undefined;
+}
+
+function hasDefaultExportModifier(node: ts.HasModifiers) {
+  const modifiers = node.modifiers ?? [];
+  return (
+    modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) &&
+    modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword)
+  );
+}
+
+function isModuleExportsExpression(expression: ts.Expression) {
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === 'module' &&
+    expression.name.text === 'exports'
+  );
+}
+
+function normalizeExpoConfigObject(config: ts.ObjectLiteralExpression) {
+  const expoProperty = findPropertyAssignment(config, 'expo');
+  if (expoProperty && ts.isObjectLiteralExpression(expoProperty.initializer)) {
+    return expoProperty.initializer;
+  }
+
+  return config;
+}
+
+function findPropertyAssignment(object: ts.ObjectLiteralExpression, name: string) {
+  return object.properties.find(
+    (property): property is ts.PropertyAssignment =>
+      ts.isPropertyAssignment(property) && getPropertyName(property.name) === name
+  );
+}
+
+function getPropertyName(name: ts.PropertyName): string | undefined {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+
+  return undefined;
+}
+
+function collectAssetReferences(node: ts.Expression, references: FileReference[]) {
+  if (ts.isObjectLiteralExpression(node)) {
+    for (const property of node.properties) {
+      if (!ts.isPropertyAssignment(property)) {
+        continue;
+      }
+
+      const keyName = getPropertyName(property.name);
+      if (!keyName || keyName === 'plugins') {
+        continue;
+      }
+
+      if (isStringLiteralNode(property.initializer)) {
+        const value = getStringValue(property.initializer);
+        if (value.startsWith('.') && ASSET_PROPERTIES.test(keyName)) {
+          references.push({
+            filePath: value,
+            fileRange: getStringNodeRange(property.initializer),
+          });
+        }
+      } else if (
+        ts.isObjectLiteralExpression(property.initializer) ||
+        ts.isArrayLiteralExpression(property.initializer)
+      ) {
+        collectAssetReferences(property.initializer, references);
+      }
+    }
+  }
+
+  if (ts.isArrayLiteralExpression(node)) {
+    for (const element of node.elements) {
+      if (ts.isObjectLiteralExpression(element) || ts.isArrayLiteralExpression(element)) {
+        collectAssetReferences(element, references);
+      }
+    }
+  }
+}
+
+function getPluginDefinition(element: ts.Expression): PluginDefinition {
+  if (isStringLiteralNode(element)) {
+    return {
+      nameValue: getStringValue(element),
+      nameRange: getStringNodeRange(element),
+    };
+  }
+
+  if (ts.isArrayLiteralExpression(element) && element.elements.length > 0) {
+    const firstElement = element.elements[0];
+    if (isStringLiteralNode(firstElement)) {
+      return {
+        nameValue: getStringValue(firstElement),
+        nameRange: getStringNodeRange(firstElement),
+      };
+    }
+  }
+
+  return {
+    nameRange: getNodeRange(element),
+  };
+}
+
+function getPluginContext(node: ts.Node): StringReferenceContext | undefined {
+  const pluginElement = findAncestor(node, (ancestor) => {
+    if (!ts.isArrayLiteralExpression(ancestor)) {
+      return false;
+    }
+
+    const parent = ancestor.parent;
+    return (
+      ts.isPropertyAssignment(parent) &&
+      getPropertyName(parent.name) === 'plugins' &&
+      parent.initializer === ancestor
+    );
+  });
+
+  if (!pluginElement || !isStringLiteralNode(node)) {
+    return undefined;
+  }
+
+  const tuple = findAncestor(node, ts.isArrayLiteralExpression);
+  if (tuple && tuple !== pluginElement && tuple.elements[0] !== node) {
+    return undefined;
+  }
+
+  return {
+    kind: 'plugin',
+    value: getStringValue(node),
+  };
+}
+
+function getAssetContext(node: ts.Node): StringReferenceContext | undefined {
+  if (!isStringLiteralNode(node) || !node.parent || !ts.isPropertyAssignment(node.parent)) {
+    return undefined;
+  }
+
+  if (node.parent.initializer !== node) {
+    return undefined;
+  }
+
+  const keyName = getPropertyName(node.parent.name);
+  const value = getStringValue(node);
+
+  if (!keyName || !value.startsWith('.') || !ASSET_PROPERTIES.test(keyName)) {
+    return undefined;
+  }
+
+  return {
+    kind: 'asset',
+    keyName,
+    value,
+  };
+}
+
+function findStringNodeAtOffset(sourceFile: ts.SourceFile, offset: number) {
+  let bestMatch: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral | undefined;
+
+  function visit(node: ts.Node) {
+    if (offset < node.getStart(sourceFile) || offset > node.getEnd()) {
+      return;
+    }
+
+    if (isStringLiteralNode(node)) {
+      const start = node.getStart(sourceFile) + 1;
+      const end = node.getEnd() - 1;
+      if (offset >= start && offset <= end) {
+        bestMatch = node;
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return bestMatch;
+}
+
+function findAncestor<T extends ts.Node>(
+  node: ts.Node,
+  predicate: (node: ts.Node) => node is T
+): T | undefined;
+function findAncestor(node: ts.Node, predicate: (node: ts.Node) => boolean): ts.Node | undefined;
+function findAncestor(node: ts.Node, predicate: (node: ts.Node) => boolean) {
+  let current = node.parent;
+  while (current) {
+    if (predicate(current)) {
+      return current;
+    }
+    current = current.parent;
+  }
+
+  return undefined;
+}
+
+function isStringLiteralNode(
+  node: ts.Node
+): node is ts.StringLiteral | ts.NoSubstitutionTemplateLiteral {
+  return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node);
+}
+
+function getStringValue(node: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral) {
+  return node.text;
+}
+
+function getStringNodeRange(node: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral): Range {
+  return {
+    offset: node.getStart() + 1,
+    length: Math.max(0, node.getEnd() - node.getStart() - 2),
+  };
+}
+
+function getNodeRange(node: ts.Node): Range {
+  return {
+    offset: node.getStart(),
+    length: node.getEnd() - node.getStart(),
+  };
+}
+
+export function getDynamicReferenceDirectoryPath(reference: string) {
+  return getDirectoryPath(reference) ?? '';
+}
+
+export function isDynamicPluginFile(entityName: string) {
+  return path.extname(entityName) === '.js';
+}

--- a/src/expo/manifest.ts
+++ b/src/expo/manifest.ts
@@ -1,5 +1,5 @@
 import { Range } from 'jsonc-parser';
-import { DocumentFilter } from 'vscode';
+import { DocumentFilter, DocumentSelector, TextDocument, languages } from 'vscode';
 
 export type FileReference = {
   filePath: string;
@@ -10,11 +10,34 @@ export type FileReference = {
  * Select documents matching `app.json` or `app.config.json`.
  * Note, language is set to JSONC instead of JSON(5) to enable comments.
  */
-export const manifestPattern: DocumentFilter = {
+export const jsonManifestPattern: DocumentFilter = {
   scheme: 'file',
   language: 'jsonc',
   pattern: '**/*/app{,.config}.json',
 };
+
+export const dynamicManifestPattern: DocumentSelector = [
+  {
+    scheme: 'file',
+    language: 'javascript',
+    pattern: '**/*/app.config.js',
+  },
+  {
+    scheme: 'file',
+    language: 'typescript',
+    pattern: '**/*/app.config.ts',
+  },
+];
+
+export const manifestPattern: DocumentSelector = [jsonManifestPattern, ...dynamicManifestPattern];
+
+export function isJsonManifestDocument(document: TextDocument) {
+  return languages.match(jsonManifestPattern, document) > 0;
+}
+
+export function isDynamicManifestDocument(document: TextDocument) {
+  return languages.match(dynamicManifestPattern, document) > 0;
+}
 
 /**
  * Find all (sub)strings that might be a file path.

--- a/src/manifestAssetCompletions.ts
+++ b/src/manifestAssetCompletions.ts
@@ -2,7 +2,11 @@ import { findNodeAtLocation, findNodeAtOffset, getNodeValue } from 'jsonc-parser
 import path from 'path';
 import vscode from 'vscode';
 
-import { manifestPattern } from './expo/manifest';
+import {
+  getDynamicReferenceDirectoryPath,
+  getDynamicStringReferenceContext,
+} from './expo/dynamicManifest';
+import { isDynamicManifestDocument, manifestPattern } from './expo/manifest';
 import { ExpoProjectCache } from './expo/project';
 import {
   changedManifestFileReferencesEnabled,
@@ -55,8 +59,43 @@ export class ManifestAssetCompletionsProvider extends ExpoCompletionsProvider {
     if (!this.isEnabled) return null;
 
     const project = await this.projects.fromManifest(document);
-    if (!project?.manifest) {
+    if (!project) {
       log('Could not resolve project from manifest "%s"', document.fileName);
+      return [];
+    }
+
+    const dynamicContext = isDynamicManifestDocument(document)
+      ? getDynamicStringReferenceContext(document, position)
+      : undefined;
+    if (dynamicContext?.kind === 'asset' && !token.isCancellationRequested) {
+      const positionDir = getDynamicReferenceDirectoryPath(dynamicContext.value);
+      const entities = await withCancelToken(token, () =>
+        vscode.workspace.fs.readDirectory(vscode.Uri.joinPath(project.root, positionDir))
+      );
+
+      return entities
+        ?.map(([entityName, entityType]) => {
+          if (fileIsHidden(entityName) || fileIsExcluded(entityName, this.excludedFiles)) {
+            return null;
+          }
+
+          if (entityType === vscode.FileType.Directory) {
+            return createFolder(entityName);
+          }
+
+          if (
+            entityType === vscode.FileType.File &&
+            ASSET_EXTENSIONS.includes(path.extname(entityName))
+          ) {
+            return createFile(entityName);
+          }
+
+          return null;
+        })
+        .filter(truthy);
+    }
+
+    if (!project.manifest) {
       return [];
     }
 
@@ -70,7 +109,11 @@ export class ManifestAssetCompletionsProvider extends ExpoCompletionsProvider {
 
     // Abort if the path is not relative, or if there is an extension already
     const positionValue = getNodeValue(positionNode);
-    if (!positionValue?.startsWith('.') || path.extname(positionValue)) {
+    if (
+      typeof positionValue !== 'string' ||
+      !positionValue.startsWith('.') ||
+      path.extname(positionValue)
+    ) {
       return null;
     }
 

--- a/src/manifestDiagnostics.ts
+++ b/src/manifestDiagnostics.ts
@@ -1,7 +1,12 @@
 import { findNodeAtLocation, Node } from 'jsonc-parser';
 import vscode from 'vscode';
 
-import { type FileReference, getFileReferences, manifestPattern } from './expo/manifest';
+import {
+  type FileReference,
+  getDynamicAssetReferences,
+  getDynamicPluginDefinitions,
+} from './expo/dynamicManifest';
+import { getFileReferences, isDynamicManifestDocument, manifestPattern } from './expo/manifest';
 import { getPluginDefinition, resolvePluginFunctionUnsafe } from './expo/plugin';
 import { ExpoProject, ExpoProjectCache } from './expo/project';
 import {
@@ -47,8 +52,26 @@ export class ManifestDiagnosticsProvider extends ExpoDiagnosticsProvider {
     if (!this.isEnabled) return issues;
 
     const project = await this.projects.fromManifest(document);
-    if (!project?.manifest) {
+    if (!project) {
       log('Could not resolve project from manifest "%s"', document.fileName);
+      return issues;
+    }
+
+    if (isDynamicManifestDocument(document)) {
+      for (const plugin of getDynamicPluginDefinitions(document)) {
+        const issue = diagnoseDynamicPlugin(document, project, plugin);
+        if (issue) issues.push(issue);
+      }
+
+      for (const reference of getDynamicAssetReferences(document)) {
+        const issue = await diagnoseAsset(document, project, reference);
+        if (issue) issues.push(issue);
+      }
+
+      return issues;
+    }
+
+    if (!project.manifest) {
       return issues;
     }
 
@@ -72,6 +95,46 @@ export class ManifestDiagnosticsProvider extends ExpoDiagnosticsProvider {
     }
 
     return issues;
+  }
+}
+
+function diagnoseDynamicPlugin(
+  document: vscode.TextDocument,
+  project: ExpoProject,
+  plugin: { nameRange: { offset: number; length: number }; nameValue?: string }
+) {
+  if (!plugin.nameValue) {
+    const issue = new vscode.Diagnostic(
+      getDocumentRange(document, plugin.nameRange),
+      `Plugin definition is empty, expected a file or dependency name`,
+      vscode.DiagnosticSeverity.Warning
+    );
+    issue.code = PluginIssueCode.definitionInvalid;
+    return issue;
+  }
+
+  try {
+    resetModuleFrom(project.root.fsPath, plugin.nameValue);
+    resolvePluginFunctionUnsafe(project.root.fsPath, plugin.nameValue);
+  } catch (error) {
+    const issue = new vscode.Diagnostic(
+      getDocumentRange(document, plugin.nameRange),
+      error.message,
+      vscode.DiagnosticSeverity.Warning
+    );
+
+    issue.code = error.code;
+
+    if (error.code === 'PLUGIN_NOT_FOUND') {
+      issue.message = `Plugin not found: ${plugin.nameValue}`;
+    }
+
+    if (error.name === 'TypeError' && error.message?.includes(`null (reading 'default')`)) {
+      issue.message = `Plugin exports null, expected a plugin function: ${plugin.nameValue}`;
+      issue.code = PluginIssueCode.functionInvalid;
+    }
+
+    return issue;
   }
 }
 

--- a/src/manifestLinks.ts
+++ b/src/manifestLinks.ts
@@ -1,7 +1,8 @@
 import { findNodeAtLocation } from 'jsonc-parser';
 import vscode from 'vscode';
 
-import { getFileReferences, manifestPattern } from './expo/manifest';
+import { getDynamicAssetReferences, getDynamicPluginDefinitions } from './expo/dynamicManifest';
+import { getFileReferences, isDynamicManifestDocument, manifestPattern } from './expo/manifest';
 import { getPluginDefinition, resolvePluginInfo } from './expo/plugin';
 import { ExpoProjectCache } from './expo/project';
 import { changedManifestFileReferencesEnabled, isManifestFileReferencesEnabled } from './settings';
@@ -33,8 +34,44 @@ export class ManifestLinksProvider extends ExpoLinkProvider {
     if (!this.isEnabled) return links;
 
     const project = await this.projects.fromManifest(document);
-    if (!project?.manifest) {
+    if (!project) {
       log('Could not resolve project from manifest "%s"', document.fileName);
+      return links;
+    }
+
+    if (isDynamicManifestDocument(document)) {
+      for (const pluginDefinition of getDynamicPluginDefinitions(document)) {
+        if (token.isCancellationRequested) return links;
+        if (!pluginDefinition.nameValue) continue;
+
+        const plugin = resolvePluginInfo(project.root.fsPath, pluginDefinition.nameValue);
+        if (plugin) {
+          const link = new vscode.DocumentLink(
+            getDocumentRange(document, pluginDefinition.nameRange),
+            vscode.Uri.file(plugin.pluginFile)
+          );
+
+          link.tooltip = 'Go to plugin';
+          links.push(link);
+        }
+      }
+
+      for (const reference of getDynamicAssetReferences(document)) {
+        if (token.isCancellationRequested) return links;
+
+        const link = new vscode.DocumentLink(
+          getDocumentRange(document, reference.fileRange),
+          vscode.Uri.joinPath(project.root, reference.filePath)
+        );
+
+        link.tooltip = 'Go to asset';
+        links.push(link);
+      }
+
+      return links;
+    }
+
+    if (!project.manifest) {
       return links;
     }
 

--- a/src/manifestPluginCompletions.ts
+++ b/src/manifestPluginCompletions.ts
@@ -2,7 +2,12 @@ import { findNodeAtLocation, findNodeAtOffset, getNodeValue } from 'jsonc-parser
 import path from 'path';
 import vscode from 'vscode';
 
-import { manifestPattern } from './expo/manifest';
+import {
+  getDynamicReferenceDirectoryPath,
+  getDynamicStringReferenceContext,
+  isDynamicPluginFile,
+} from './expo/dynamicManifest';
+import { isDynamicManifestDocument, manifestPattern } from './expo/manifest';
 import { type PluginInfo, resolveInstalledPluginInfo, resolvePluginInfo } from './expo/plugin';
 import { ExpoProjectCache } from './expo/project';
 import {
@@ -53,8 +58,56 @@ export class ManifestPluginCompletionsProvider extends ExpoCompletionsProvider {
     if (!this.isEnabled) return null;
 
     const project = await this.projects.fromManifest(document);
-    if (!project?.manifest) {
+    if (!project) {
       log('Could not resolve project from manifest "%s"', document.fileName);
+      return [];
+    }
+
+    const dynamicContext = isDynamicManifestDocument(document)
+      ? getDynamicStringReferenceContext(document, position)
+      : undefined;
+    if (dynamicContext?.kind === 'plugin') {
+      const positionIsPath = dynamicContext.value.startsWith('./');
+
+      if (!positionIsPath && !token.isCancellationRequested) {
+        return createPossibleIncompleteList(
+          resolveInstalledPluginInfo(project, dynamicContext.value, MAX_RESULT).map((plugin) =>
+            createPluginModule(plugin)
+          )
+        );
+      }
+
+      if (positionIsPath && !token.isCancellationRequested) {
+        const positionDir = getDynamicReferenceDirectoryPath(dynamicContext.value);
+        const entities = await withCancelToken(token, () =>
+          vscode.workspace.fs.readDirectory(vscode.Uri.joinPath(project.root, positionDir))
+        );
+
+        return entities
+          ?.map(([entityName, entityType]) => {
+            if (fileIsHidden(entityName) || fileIsExcluded(entityName, this.excludedFiles)) {
+              return null;
+            }
+
+            if (entityType === vscode.FileType.Directory) {
+              return createFolder(entityName);
+            }
+
+            if (isDynamicPluginFile(entityName)) {
+              const pluginPath = './' + path.join(positionDir, entityName);
+              const plugin = resolvePluginInfo(project.root.fsPath, pluginPath);
+              if (plugin) {
+                return createPluginFile(plugin, entityName);
+              }
+            }
+
+            return null;
+          })
+          .filter(truthy);
+      }
+    }
+
+    if (!project.manifest) {
       return [];
     }
 

--- a/test/fixture/manifest/app.config.js
+++ b/test/fixture/manifest/app.config.js
@@ -1,0 +1,37 @@
+module.exports = {
+  name: 'manifest',
+  slug: 'manifest',
+  description: 'This fixture was created for all manifest related tasks',
+  version: '1.0.0',
+  orientation: 'portrait',
+  icon: './assets/icon.png',
+  userInterfaceStyle: 'light',
+  splash: {
+    image: './assets/splash.png',
+    resizeMode: 'contain',
+    backgroundColor: '#ffffff',
+  },
+  assetBundlePatterns: ['**/*'],
+  ios: {
+    supportsTablet: true,
+  },
+  android: {
+    adaptiveIcon: {
+      foregroundImage: './assets/adaptive-icon.png',
+      backgroundColor: '#ffffff',
+    },
+  },
+  web: {
+    favicon: './assets/favicon.png',
+  },
+  plugins: [
+    'expo-system-ui',
+    [
+      'expo-camera',
+      {
+        cameraPermission: 'This tests the multiple variants of defining plugins',
+      },
+    ],
+    './plugins/valid',
+  ],
+};

--- a/test/fixture/manifest/app.config.ts
+++ b/test/fixture/manifest/app.config.ts
@@ -1,0 +1,39 @@
+const config = {
+  name: 'manifest',
+  slug: 'manifest',
+  description: 'This fixture was created for all manifest related tasks',
+  version: '1.0.0',
+  orientation: 'portrait',
+  icon: './assets/icon.png',
+  userInterfaceStyle: 'light',
+  splash: {
+    image: './assets/splash.png',
+    resizeMode: 'contain',
+    backgroundColor: '#ffffff',
+  },
+  assetBundlePatterns: ['**/*'],
+  ios: {
+    supportsTablet: true,
+  },
+  android: {
+    adaptiveIcon: {
+      foregroundImage: './assets/adaptive-icon.png',
+      backgroundColor: '#ffffff',
+    },
+  },
+  web: {
+    favicon: './assets/favicon.png',
+  },
+  plugins: [
+    'expo-system-ui',
+    [
+      'expo-camera',
+      {
+        cameraPermission: 'This tests the multiple variants of defining plugins',
+      },
+    ],
+    './plugins/valid',
+  ],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add manifest provider support for object-literal `app.config.js` and `app.config.ts` files
- keep JSON manifest behavior intact while extending links, diagnostics, and completions to dynamic config files
- add dynamic-config fixtures and focused VS Code e2e coverage for asset and local plugin workflows

## Details
- expand manifest selectors to include `app.config.js` and `app.config.ts`
- add a lightweight TypeScript AST helper to find Expo config object literals, asset references, and plugin definitions
- teach manifest links, diagnostics, asset completions, and plugin completions to use those helpers for dynamic configs
- update the extension setting descriptions to reflect support for object-literal JS/TS configs

## Verification
- `npm run build`
- `npm run lint`
- `VSCODE_EXPO_TEST_PATTERN=dynamicManifest npm run test:vscode`